### PR TITLE
Fix decompiler else-if chain bug

### DIFF
--- a/Source/AtlusScriptCompiler/Resources/Tests.flow
+++ b/Source/AtlusScriptCompiler/Resources/Tests.flow
@@ -397,7 +397,8 @@ bool ForTest()
 {
 	//PUTS( "TestScript::ForTest() start" );
 	
-	for ( int i = 0; i < 10; i++ )
+	int i = 0;
+	for ( i = 0; i < 10; i++ )
 	{
 	}
 	
@@ -446,7 +447,8 @@ bool ForContinueTest()
 {
 	//PUTS( "TestScript::ForContinueTest() start" );
 	
-	for ( int i = 0; i < 10; i++ )
+	int i = 0;
+	for ( i = 0; i < 10; i++ )
 	{
 		continue;
 		

--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Decompiler/CompilationUnitWriter.cs
@@ -380,7 +380,7 @@ namespace AtlusScriptLibrary.FlowScriptLanguage.Decompiler
                     WriteIndentation();
                     WriteWithSeperator( "else" );
 
-                    if ( ifStatement.ElseBody.Statements.Count > 0 &&
+                    if ( ifStatement.ElseBody.Statements.Count == 1 &&
                          ifStatement.ElseBody.Statements[ 0 ] is IfStatement )
                     {
                         // Write else if { }, instead of else { if { } }


### PR DESCRIPTION
Fixes #40, fixes #9

This fixes an else-if chain bug in the decompiler incorrectly removing brackets `{ }` from else-statements whose bodies contain more than one statement, other than a single if-statement.

It is caused by a special case when writing a compilation unit, which omits `{ }` from else clauses if the first statement in the else body is another if-statement, which ensures pretty else-if chains in the output. However, it would incorrectly do this if the else-body had additional statements following the if-statement, leading to those statements being left out of the else body in the output.

This would cause decompiled and recompiled scripts to have inconsistent logic, leading to strange behavior in the game and sometimes crashing. I have tested the situations where crashes happened in issue #9, before and after the fix, and can confirm that this fix resolves those crashes.

The fix was changing a single line in `CompilationUnitWriter.cs`, such that it only omits the brackets if the if-statement is the *only* statement in the else body. Otherwise the brackets will be left in.

An example from P5R's FIELD.BF (located at CPK\EN.CPK\FIELD\ETC\FIELD.BF)
The correct logic for the `fld_r1_menu()` procedure is as follows:
```
void fld_r1_menu()
{
    if ( BIT_CHK( ( 0x20000000 + 65 ) ) )
    {
        return;
    }
    else if ( ( CHK_DAYS( 11, 22 ) == 1 ) && ( GET_TIME() == 4 ) )
    {
        return;
    }
    else if ( BIT_CHK( ( 0 + 96 ) ) )
    {
        KeyfreeEvent_SHORTCUT();
    }
    else if ( BIT_CHK( ( 1342177280 + 270 ) ) )
    {
        MyPalace_SHORTCUT();
    }
    else 
    {
        
        if ( ( BIT_CHK( ( 0x10000000 + 546 ) ) == 1 ) && ( BIT_CHK( ( 0 + 744 ) ) == 0 ) )
        {
            BIT_ON( ( 0 + 744 ) );
        }

        Field_SHORTCUT();
    }

}
```
However, the decompiler would produce:
```
void fld_r1_menu()
{
    if ( BIT_CHK( ( 0x20000000 + 65 ) ) )
    {
        return;
    }
    else if ( ( CHK_DAYS( 11, 22 ) == 1 ) && ( GET_TIME() == 4 ) )
    {
        return;
    }
    else if ( BIT_CHK( ( 0 + 96 ) ) )
    {
        KeyfreeEvent_SHORTCUT();
    }
    else if ( BIT_CHK( ( 1342177280 + 270 ) ) )
    {
        MyPalace_SHORTCUT();
    }
    else if ( ( BIT_CHK( ( 0x10000000 + 546 ) ) == 1 ) && ( BIT_CHK( ( 0 + 744 ) ) == 0 ) )
    {
        BIT_ON( ( 0 + 744 ) );
    }

    Field_SHORTCUT();

}
```
Leading to `Field_SHORTCUT()` being called in any case, which is not correct