### PR TITLE
Fix appveyor latest build link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WIP set of tools developed for handling Atlus' script formats including
 All of the code is written in C# and licensed under the GNU GPL.
 
 Latest build:
-* https://ci.appveyor.com/project/tge/atlusscripttools/build/artifacts
+* https://ci.appveyor.com/project/tge-was-taken/atlus-script-tools/build/artifacts
 
 ## Overview of repository structure ##
 


### PR DESCRIPTION
The currently displayed link takes you to an appveyor page for a 2 year old build of AtlusScriptTools with no artifacts available to download; this PR fixes the link to be the same as what's used for the appveyor "build status" icon, which takes you to the correct page to download the actual latest builds (if the artifact for it hasn't expired, of course.)