### PR TITLE
Add Default Aliases To Libraries

### DIFF
--- a/Scripts/addAliases.py
+++ b/Scripts/addAliases.py
@@ -1,17 +1,54 @@
 import os
 import json
 
+## ======================================================================
+## This script adds default aliases to all libraries that need them.
+##
+## That is, if a function had a default name like FUNCTION_0003 but was 
+## at some point given a real name like SEL, that default name will be 
+## added as an alias. 
+##
+## This allows flowscript files that were decompiled prior to the name
+## being updated to still work.
+##
+## Note that some of the games had their function names included in the
+## executable so they never had these unknown names. These are excluded
+## from this script. Seee the ignoredFolders variable below.
+## ======================================================================
+
+# Path to the libraries
+folder_path = '../Source/AtlusScriptLibrary/Libraries'
+    
+# Folders to ignore since the game's contained the real function names
+ignoredFolders = [
+    "Nocturne",
+    "Persona5",
+    "Persona5Royal",
+    "Persona3Reload"
+]
+
+def is_ignored_folder(folder: str) -> bool:
+    for ignored in ignoredFolders:
+        if ignored in folder:
+            return True
+    return False
+
 def get_folder_prefix(folder_name):
     # Define folder-specific prefixes
     folder_prefixes = {
         'AI': 'AI_',
+        'Battle': 'BTL_',
         'Common': '',
+        'Camp': 'CAMP_',
+        'Dungeon': 'DNG_',
         'Event': 'EVT_',
         'Facility': 'FCL_',
         'Field': 'FLD_',
-        'Shared': 'SHD_',
+        "Map": 'MAP_',
         'Net': 'NET_',
-        # Add more folder names and prefixes as needed
+        'Script': 'SCR_',
+        'Shared': 'SHD_',
+        'Window': 'WND_',
     }
     
     # Return the prefix or an empty string if the folder is not in the dictionary
@@ -34,7 +71,7 @@ def process_json_file(file_path):
     folder_prefix = get_folder_prefix(folder_name)
 
     print(f"Parsing {file_path}")
-    with open(file_path, 'r') as file:
+    with open(file_path, 'r', encoding='utf-8-sig') as file:
         data = json.load(file)
 
     # Iterate through each function in the array and add the alias
@@ -47,11 +84,11 @@ def process_json_file(file_path):
 
 def process_folder(folder_path):
     for root, dirs, files in os.walk(folder_path):
-        for file in files:
-            if file.endswith('Functions.json'):
-                file_path = os.path.join(root, file)
-                process_json_file(file_path)
+        if not is_ignored_folder(root):
+            for file in files:
+                if file.endswith('Functions.json'):
+                    file_path = os.path.join(root, file)
+                    process_json_file(file_path)
 
-# Path to the libraries
-folder_path = '../Source/AtlusScriptLibrary/Libraries'
-process_folder(folder_path)
+if __name__ == "__main__":
+    process_folder(folder_path)

--- a/Source/AtlusScriptLibrary/Libraries/DigitalDevilSaga/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/DigitalDevilSaga/Modules/Common/Functions.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "Index": "0x0000",
     "ReturnType": "int",
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,7 +21,9 @@
     "ReturnType": "int",
     "Name": "MSG_WND_DSP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0001"
     ]
   },
   {
@@ -26,7 +31,9 @@
     "ReturnType": "int",
     "Name": "MSG_WND_CLS",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -47,16 +54,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0005",
     "ReturnType": "int",
     "Name": "FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0006",
@@ -83,6 +88,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0007"
     ]
   },
   {
@@ -97,6 +105,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0008"
     ]
   },
   {
@@ -111,6 +122,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -124,6 +138,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000A"
     ]
   },
   {
@@ -157,8 +174,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x000e",
@@ -485,8 +501,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_001D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x001e",
@@ -519,8 +534,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0020",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0021",
@@ -558,8 +572,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0024",
@@ -579,24 +592,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0025",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0026",
     "ReturnType": "int",
     "Name": "FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0027",
     "ReturnType": "int",
     "Name": "FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0028",
@@ -621,8 +631,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0029",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002a",
@@ -681,8 +690,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_002E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002f",
@@ -702,7 +710,9 @@
     "ReturnType": "int",
     "Name": "AI_ACT_ATTACK",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0030"
     ]
   },
   {
@@ -710,16 +720,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0031",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0032",
     "ReturnType": "int",
     "Name": "FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0033",
@@ -732,6 +740,9 @@
         "Name": "skill",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0033"
     ]
   },
   {
@@ -739,7 +750,9 @@
     "ReturnType": "int",
     "Name": "AI_TAR_RND",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0034"
     ]
   },
   {
@@ -747,8 +760,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0035",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0036",
@@ -833,15 +845,16 @@
     "ReturnType": "int",
     "Name": "FUNCTION_003C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x003d",
     "ReturnType": "int",
     "Name": "AI_ACT_WAIT",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_003D"
     ]
   },
   {
@@ -849,16 +862,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_003E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x003f",
     "ReturnType": "int",
     "Name": "FUNCTION_003F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0040",
@@ -904,8 +915,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0043",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0044",
@@ -930,16 +940,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0045",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0046",
     "ReturnType": "int",
     "Name": "FUNCTION_0046",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0047",
@@ -1072,16 +1080,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_004E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004f",
     "ReturnType": "int",
     "Name": "FUNCTION_004F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0050",
@@ -1101,16 +1107,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0051",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0052",
     "ReturnType": "int",
     "Name": "FUNCTION_0052",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0053",
@@ -1238,24 +1242,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_005A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005b",
     "ReturnType": "int",
     "Name": "FUNCTION_005B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005c",
     "ReturnType": "int",
     "Name": "FUNCTION_005C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005d",
@@ -1311,40 +1312,35 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0060",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0061",
     "ReturnType": "int",
     "Name": "FUNCTION_0061",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0062",
     "ReturnType": "int",
     "Name": "FUNCTION_0062",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0063",
     "ReturnType": "int",
     "Name": "FUNCTION_0063",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0064",
     "ReturnType": "int",
     "Name": "FUNCTION_0064",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0065",
@@ -1390,8 +1386,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0068",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0069",
@@ -1473,16 +1468,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_006E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x006f",
     "ReturnType": "int",
     "Name": "FUNCTION_006F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0070",
@@ -1599,8 +1592,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0075",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0076",
@@ -1738,6 +1730,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_007B"
     ]
   },
   {
@@ -1758,8 +1753,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_007D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x007e",
@@ -1772,6 +1766,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_007E"
     ]
   },
   {
@@ -1876,6 +1873,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0086"
     ]
   },
   {
@@ -1889,6 +1889,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0087"
     ]
   },
   {
@@ -1896,8 +1899,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0088",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0089",
@@ -1973,8 +1975,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_008C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008d",
@@ -2048,16 +2049,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0091",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0092",
     "ReturnType": "int",
     "Name": "FUNCTION_0092",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0093",
@@ -2192,8 +2191,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0099",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x009a",
@@ -2365,8 +2363,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00A4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a5",
@@ -2479,8 +2476,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00AC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00ad",
@@ -2916,16 +2912,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00BF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00c0",
     "ReturnType": "int",
     "Name": "FUNCTION_00C0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00c1",
@@ -3475,16 +3469,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00E0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e1",
     "ReturnType": "int",
     "Name": "FUNCTION_00E1",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e2",
@@ -3502,6 +3494,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E2"
     ]
   },
   {
@@ -3522,24 +3517,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00E4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e5",
     "ReturnType": "int",
     "Name": "FUNCTION_00E5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e6",
     "ReturnType": "int",
     "Name": "FUNCTION_00E6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e7",
@@ -3848,16 +3840,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00F5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00f6",
     "ReturnType": "int",
     "Name": "FUNCTION_00F6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00f7",
@@ -3903,48 +3893,42 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00FA",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00fb",
     "ReturnType": "int",
     "Name": "FUNCTION_00FB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00fc",
     "ReturnType": "int",
     "Name": "FUNCTION_00FC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00fd",
     "ReturnType": "int",
     "Name": "FUNCTION_00FD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00fe",
     "ReturnType": "int",
     "Name": "FUNCTION_00FE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00ff",
     "ReturnType": "int",
     "Name": "FUNCTION_00FF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0100",
@@ -4439,16 +4423,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0115",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0116",
     "ReturnType": "int",
     "Name": "FUNCTION_0116",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0117",
@@ -4473,8 +4455,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0118",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0119",
@@ -4520,8 +4501,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_011C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x011d",
@@ -4554,32 +4534,28 @@
     "ReturnType": "int",
     "Name": "FUNCTION_011F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0120",
     "ReturnType": "int",
     "Name": "FUNCTION_0120",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0121",
     "ReturnType": "int",
     "Name": "FUNCTION_0121",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0122",
     "ReturnType": "int",
     "Name": "FUNCTION_0122",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0123",
@@ -4612,16 +4588,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0125",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0126",
     "ReturnType": "int",
     "Name": "FUNCTION_0126",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0127",
@@ -4994,40 +4968,35 @@
     "ReturnType": "int",
     "Name": "FUNCTION_013D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x013e",
     "ReturnType": "int",
     "Name": "FUNCTION_013E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x013f",
     "ReturnType": "int",
     "Name": "FUNCTION_013F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0140",
     "ReturnType": "int",
     "Name": "FUNCTION_0140",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0141",
     "ReturnType": "int",
     "Name": "FUNCTION_0141",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0142",
@@ -5185,8 +5154,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0149",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014a",
@@ -5219,128 +5187,112 @@
     "ReturnType": "bool",
     "Name": "FUNCTION_014C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014d",
     "ReturnType": "int",
     "Name": "FUNCTION_014D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014e",
     "ReturnType": "int",
     "Name": "FUNCTION_014E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014f",
     "ReturnType": "int",
     "Name": "FUNCTION_014F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0150",
     "ReturnType": "int",
     "Name": "FUNCTION_0150",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0151",
     "ReturnType": "int",
     "Name": "FUNCTION_0151",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0152",
     "ReturnType": "int",
     "Name": "FUNCTION_0152",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0153",
     "ReturnType": "int",
     "Name": "FUNCTION_0153",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0154",
     "ReturnType": "int",
     "Name": "FUNCTION_0154",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0155",
     "ReturnType": "int",
     "Name": "FUNCTION_0155",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0156",
     "ReturnType": "int",
     "Name": "FUNCTION_0156",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0157",
     "ReturnType": "int",
     "Name": "FUNCTION_0157",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0158",
     "ReturnType": "int",
     "Name": "FUNCTION_0158",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0159",
     "ReturnType": "int",
     "Name": "FUNCTION_0159",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x015a",
     "ReturnType": "int",
     "Name": "FUNCTION_015A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x015b",
     "ReturnType": "int",
     "Name": "FUNCTION_015B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x015c",
@@ -5360,16 +5312,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_015D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x015e",
     "ReturnType": "int",
     "Name": "FUNCTION_015E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x015f",
@@ -5417,32 +5367,28 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0161",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0162",
     "ReturnType": "int",
     "Name": "FUNCTION_0162",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0163",
     "ReturnType": "int",
     "Name": "FUNCTION_0163",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0164",
     "ReturnType": "int",
     "Name": "FUNCTION_0164",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0165",
@@ -5531,8 +5477,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0169",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016a",
@@ -5552,8 +5497,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_016B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016c",
@@ -5573,16 +5517,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_016D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016e",
     "ReturnType": "int",
     "Name": "FUNCTION_016E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016f",
@@ -5615,72 +5557,63 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0171",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0172",
     "ReturnType": "int",
     "Name": "FUNCTION_0172",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0173",
     "ReturnType": "int",
     "Name": "FUNCTION_0173",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0174",
     "ReturnType": "int",
     "Name": "FUNCTION_0174",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0175",
     "ReturnType": "int",
     "Name": "FUNCTION_0175",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0176",
     "ReturnType": "int",
     "Name": "FUNCTION_0176",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0177",
     "ReturnType": "int",
     "Name": "FUNCTION_0177",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0178",
     "ReturnType": "int",
     "Name": "FUNCTION_0178",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0179",
     "ReturnType": "int",
     "Name": "FUNCTION_0179",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017a",
@@ -5700,16 +5633,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_017B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017c",
     "ReturnType": "int",
     "Name": "FUNCTION_017C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017d",
@@ -5747,48 +5678,42 @@
     "ReturnType": "int",
     "Name": "FUNCTION_017F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0180",
     "ReturnType": "int",
     "Name": "FUNCTION_0180",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0181",
     "ReturnType": "int",
     "Name": "FUNCTION_0181",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0182",
     "ReturnType": "int",
     "Name": "FUNCTION_0182",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0183",
     "ReturnType": "int",
     "Name": "FUNCTION_0183",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0184",
     "ReturnType": "int",
     "Name": "FUNCTION_0184",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0185",
@@ -5818,72 +5743,63 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0186",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0187",
     "ReturnType": "int",
     "Name": "FUNCTION_0187",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0188",
     "ReturnType": "int",
     "Name": "FUNCTION_0188",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0189",
     "ReturnType": "int",
     "Name": "FUNCTION_0189",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018a",
     "ReturnType": "int",
     "Name": "FUNCTION_018A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018b",
     "ReturnType": "int",
     "Name": "FUNCTION_018B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018c",
     "ReturnType": "int",
     "Name": "FUNCTION_018C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018d",
     "ReturnType": "int",
     "Name": "FUNCTION_018D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018e",
     "ReturnType": "int",
     "Name": "FUNCTION_018E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018f",
@@ -5978,16 +5894,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0195",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0196",
     "ReturnType": "int",
     "Name": "FUNCTION_0196",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0197",
@@ -6035,8 +5949,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0199",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x019a",
@@ -6101,6 +6014,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_019E"
     ]
   },
   {
@@ -6121,8 +6037,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a1",
@@ -6157,40 +6072,35 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a3",
     "ReturnType": "int",
     "Name": "FUNCTION_01A3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a4",
     "ReturnType": "int",
     "Name": "FUNCTION_01A4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a5",
     "ReturnType": "int",
     "Name": "FUNCTION_01A5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a6",
     "ReturnType": "int",
     "Name": "FUNCTION_01A6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a7",
@@ -6288,32 +6198,28 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01AE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01af",
     "ReturnType": "int",
     "Name": "FUNCTION_01AF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b0",
     "ReturnType": "int",
     "Name": "FUNCTION_01B0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b1",
     "ReturnType": "int",
     "Name": "FUNCTION_01B1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b2",
@@ -6343,8 +6249,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01B3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b4",
@@ -6374,24 +6279,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01B5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b6",
     "ReturnType": "int",
     "Name": "FUNCTION_01B6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b7",
     "ReturnType": "int",
     "Name": "FUNCTION_01B7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b8",
@@ -6450,80 +6352,70 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01BC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01bd",
     "ReturnType": "int",
     "Name": "FUNCTION_01BD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01be",
     "ReturnType": "int",
     "Name": "FUNCTION_01BE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01bf",
     "ReturnType": "int",
     "Name": "FUNCTION_01BF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c0",
     "ReturnType": "int",
     "Name": "FUNCTION_01C0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c1",
     "ReturnType": "int",
     "Name": "FUNCTION_01C1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c2",
     "ReturnType": "int",
     "Name": "FUNCTION_01C2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c3",
     "ReturnType": "int",
     "Name": "FUNCTION_01C3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c4",
     "ReturnType": "int",
     "Name": "FUNCTION_01C4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c5",
     "ReturnType": "int",
     "Name": "FUNCTION_01C5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c6",
@@ -6595,8 +6487,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01CB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01cc",
@@ -6616,8 +6507,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01CD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ce",
@@ -6637,24 +6527,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01CF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d0",
     "ReturnType": "int",
     "Name": "FUNCTION_01D0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d1",
     "ReturnType": "int",
     "Name": "FUNCTION_01D1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d2",
@@ -6687,8 +6574,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01D4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d5",
@@ -6799,64 +6685,56 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01D8",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d9",
     "ReturnType": "int",
     "Name": "FUNCTION_01D9",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01da",
     "ReturnType": "int",
     "Name": "FUNCTION_01DA",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01db",
     "ReturnType": "int",
     "Name": "FUNCTION_01DB",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01dc",
     "ReturnType": "int",
     "Name": "FUNCTION_01DC",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01dd",
     "ReturnType": "int",
     "Name": "FUNCTION_01DD",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01de",
     "ReturnType": "int",
     "Name": "FUNCTION_01DE",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01df",
     "ReturnType": "int",
     "Name": "FUNCTION_01DF",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e0",
@@ -6925,8 +6803,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01E4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e5",
@@ -6956,80 +6833,70 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01E6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e7",
     "ReturnType": "int",
     "Name": "FUNCTION_01E7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e8",
     "ReturnType": "int",
     "Name": "FUNCTION_01E8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e9",
     "ReturnType": "int",
     "Name": "FUNCTION_01E9",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ea",
     "ReturnType": "int",
     "Name": "FUNCTION_01EA",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01eb",
     "ReturnType": "int",
     "Name": "FUNCTION_01EB",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ec",
     "ReturnType": "int",
     "Name": "FUNCTION_01EC",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ed",
     "ReturnType": "int",
     "Name": "FUNCTION_01ED",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ee",
     "ReturnType": "int",
     "Name": "FUNCTION_01EE",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ef",
     "ReturnType": "int",
     "Name": "FUNCTION_01EF",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f0",
@@ -7067,8 +6934,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01F2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f3",
@@ -7170,16 +7036,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01F8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f9",
     "ReturnType": "int",
     "Name": "FUNCTION_01F9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01fa",
@@ -7212,24 +7076,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01FC",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01fd",
     "ReturnType": "int",
     "Name": "FUNCTION_01FD",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01fe",
     "ReturnType": "int",
     "Name": "FUNCTION_01FE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ff",
@@ -7275,24 +7136,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0202",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0203",
     "ReturnType": "int",
     "Name": "FUNCTION_0203",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0204",
     "ReturnType": "int",
     "Name": "FUNCTION_0204",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0205",
@@ -7335,8 +7193,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0207",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0208",
@@ -7374,16 +7231,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_020A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x020b",
     "ReturnType": "int",
     "Name": "FUNCTION_020B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x020c",
@@ -7403,16 +7258,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_020D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x020e",
     "ReturnType": "int",
     "Name": "FUNCTION_020E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x020f",
@@ -7458,16 +7311,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0212",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0213",
     "ReturnType": "int",
     "Name": "FUNCTION_0213",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0214",
@@ -7500,8 +7351,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0216",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0217",
@@ -7521,24 +7371,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0218",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0219",
     "ReturnType": "int",
     "Name": "FUNCTION_0219",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x021a",
     "ReturnType": "int",
     "Name": "FUNCTION_021A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x021b",
@@ -7597,7 +7444,6 @@
     "ReturnType": "int",
     "Name": "FUNCTION_021F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3/Modules/Common/Functions.json
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "Index": "0x0000",
     "ReturnType": "void",
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,15 +21,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0001",
     "Description": "sub_38E0D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0002",
     "ReturnType": "void",
     "Name": "MSG_FUNCTION_0002",
     "Description": "sub_38E140",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -40,6 +44,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -47,16 +54,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0004",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0005",
     "ReturnType": "void",
     "Name": "FUNCTION_0005",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0006",
@@ -95,6 +100,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0008"
     ]
   },
   {
@@ -108,6 +116,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -128,8 +139,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_000B",
     "Description": "sub_346A00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x000c",
@@ -221,6 +231,9 @@
         "Name": "param8",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000F"
     ]
   },
   {
@@ -234,6 +247,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0010"
     ]
   },
   {
@@ -241,8 +257,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0011",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0012",
@@ -255,6 +270,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0012"
     ]
   },
   {
@@ -335,6 +353,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0017"
     ]
   },
   {
@@ -410,6 +431,9 @@
         "Name": "type",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_001C"
     ]
   },
   {
@@ -507,8 +531,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0022",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0023",
@@ -560,6 +583,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0026"
     ]
   },
   {
@@ -573,6 +599,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0027"
     ]
   },
   {
@@ -624,16 +653,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002B",
     "Description": "sub_3F78C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002c",
     "ReturnType": "void",
     "Name": "FUNCTION_002C",
     "Description": "sub_3F7970",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002d",
@@ -684,8 +711,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0030",
     "Description": "sub_2FDA00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0031",
@@ -957,24 +983,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0045",
     "Description": "sub_2BC570",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0046",
     "ReturnType": "int",
     "Name": "FUNCTION_0046",
     "Description": "sub_2BC5C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0047",
     "ReturnType": "int",
     "Name": "FUNCTION_0047",
     "Description": "sub_2BC610",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0048",
@@ -1215,24 +1238,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_005A",
     "Description": "sub_2BD2C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005b",
     "ReturnType": "int",
     "Name": "FUNCTION_005B",
     "Description": "sub_2BD310",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005c",
     "ReturnType": "int",
     "Name": "FUNCTION_005C",
     "Description": "sub_2BD360",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005d",
@@ -1265,32 +1285,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_005F",
     "Description": "sub_2C0640",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0060",
     "ReturnType": "void",
     "Name": "FUNCTION_0060",
     "Description": "sub_2C06B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0061",
     "ReturnType": "void",
     "Name": "FUNCTION_0061",
     "Description": "sub_2C0720",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0062",
     "ReturnType": "void",
     "Name": "FUNCTION_0062",
     "Description": "sub_2C0790",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0063",
@@ -1336,16 +1352,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0066",
     "Description": "sub_2C0A10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0067",
     "ReturnType": "void",
     "Name": "FUNCTION_0067",
     "Description": "sub_2C0A80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0068",
@@ -1456,8 +1470,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0070",
     "Description": "sub_2BB560",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0071",
@@ -1477,16 +1490,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0072",
     "Description": "sub_2BB6C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0073",
     "ReturnType": "void",
     "Name": "FUNCTION_0073",
     "Description": "sub_2BB700",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0074",
@@ -1506,8 +1517,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0075",
     "Description": "sub_2C5430",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0076",
@@ -1581,8 +1591,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_007A",
     "Description": "sub_1BBE50",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x007b",
@@ -1621,6 +1630,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_007D"
     ]
   },
   {
@@ -1628,48 +1640,42 @@
     "ReturnType": "void",
     "Name": "FUNCTION_007E",
     "Description": "sub_1BBE80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x007f",
     "ReturnType": "void",
     "Name": "FUNCTION_007F",
     "Description": "sub_1BBF90",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0080",
     "ReturnType": "int",
     "Name": "FUNCTION_0080",
     "Description": "sub_1BBFC0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0081",
     "ReturnType": "int",
     "Name": "FUNCTION_0081",
     "Description": "sub_1BBFF0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0082",
     "ReturnType": "int",
     "Name": "FUNCTION_0082",
     "Description": "sub_1BC020",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0083",
     "ReturnType": "int",
     "Name": "FUNCTION_0083",
     "Description": "sub_1BC050",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0084",
@@ -1763,8 +1769,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0088",
     "Description": "sub_1BC1D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0089",
@@ -1804,56 +1809,49 @@
     "ReturnType": "int",
     "Name": "FUNCTION_008A",
     "Description": "sub_1BC6D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008b",
     "ReturnType": "void",
     "Name": "FUNCTION_008B",
     "Description": "sub_2C1070",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008c",
     "ReturnType": "void",
     "Name": "FUNCTION_008C",
     "Description": "sub_2C10E0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008d",
     "ReturnType": "void",
     "Name": "FUNCTION_008D",
     "Description": "sub_2C1150",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008e",
     "ReturnType": "int",
     "Name": "FUNCTION_008E",
     "Description": "sub_2BD510",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008f",
     "ReturnType": "int",
     "Name": "FUNCTION_008F",
     "Description": "sub_2BD560",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0090",
     "ReturnType": "void",
     "Name": "FUNCTION_0090",
     "Description": "sub_2BB8D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0091",
@@ -1878,16 +1876,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0092",
     "Description": "sub_33BBC0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0093",
     "ReturnType": "void",
     "Name": "FUNCTION_0093",
     "Description": "sub_2FDB20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0094",
@@ -2133,8 +2129,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00A6",
     "Description": "sub_272860",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a7",
@@ -2365,16 +2360,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00B4",
     "Description": "sub_2C1740",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b5",
     "ReturnType": "void",
     "Name": "FUNCTION_00B5",
     "Description": "sub_34B1A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b6",
@@ -2417,6 +2410,9 @@
         "Name": "param7",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00B6"
     ]
   },
   {
@@ -2443,6 +2439,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00B8"
     ]
   },
   {
@@ -2468,16 +2467,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00BA",
     "Description": "sub_34AC10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bb",
     "ReturnType": "int",
     "Name": "FUNCTION_00BB",
     "Description": "sub_34AD60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bc",
@@ -2535,16 +2532,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00BE",
     "Description": "None",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bf",
     "ReturnType": "void",
     "Name": "FUNCTION_00BF",
     "Description": "None",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00c0",
@@ -2782,6 +2777,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00CF"
     ]
   },
   {
@@ -2800,6 +2798,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D0"
     ]
   },
   {
@@ -2807,8 +2808,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00D1",
     "Description": "sub_16CD90",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00d2",
@@ -2821,6 +2821,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D2"
     ]
   },
   {
@@ -2834,6 +2837,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D3"
     ]
   },
   {
@@ -2867,16 +2873,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00D6",
     "Description": "sub_1BBD80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00d7",
     "ReturnType": "int",
     "Name": "FUNCTION_00D7",
     "Description": "sub_1BCFC0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00d8",
@@ -2925,6 +2929,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DA"
     ]
   },
   {
@@ -2938,6 +2945,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DB"
     ]
   },
   {
@@ -2951,6 +2961,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DC"
     ]
   },
   {
@@ -2964,6 +2977,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DD"
     ]
   },
   {
@@ -2971,15 +2987,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00DE",
     "Description": "sub_34B130",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00df",
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_00DF",
     "Description": "sub_34B670",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00DF"
     ]
   },
   {
@@ -2993,6 +3010,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E0"
     ]
   },
   {
@@ -3006,6 +3026,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E1"
     ]
   },
   {
@@ -3013,56 +3036,49 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00E2",
     "Description": "sub_1BD0B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e3",
     "ReturnType": "int",
     "Name": "FUNCTION_00E3",
     "Description": "sub_1BD0E0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e4",
     "ReturnType": "int",
     "Name": "FUNCTION_00E4",
     "Description": "sub_1BD210",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e5",
     "ReturnType": "int",
     "Name": "FUNCTION_00E5",
     "Description": "sub_1BD2A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e6",
     "ReturnType": "int",
     "Name": "FUNCTION_00E6",
     "Description": "sub_1BD2D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e7",
     "ReturnType": "void",
     "Name": "FUNCTION_00E7",
     "Description": "sub_1BD300",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e8",
     "ReturnType": "int",
     "Name": "FUNCTION_00E8",
     "Description": "sub_1BD330",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e9",
@@ -3093,6 +3109,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00EA"
     ]
   },
   {
@@ -3390,8 +3409,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00FF",
     "Description": "sub_2C26E0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0100",
@@ -3584,8 +3602,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_010C",
     "Description": "sub_2C40B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x010d",
@@ -3605,16 +3622,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_010E",
     "Description": "sub_2C4350",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x010f",
     "ReturnType": "int",
     "Name": "FUNCTION_010F",
     "Description": "sub_2C4470",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0110",
@@ -3660,8 +3675,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0113",
     "Description": "sub_2C3BF0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0114",
@@ -3699,8 +3713,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0116",
     "Description": "sub_1BD240",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0117",
@@ -3821,6 +3834,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_011D"
     ]
   },
   {
@@ -3878,6 +3894,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0121"
     ]
   },
   {
@@ -3896,6 +3915,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0122"
     ]
   },
   {
@@ -3922,6 +3944,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0124"
     ]
   },
   {
@@ -3935,6 +3960,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0125"
     ]
   },
   {
@@ -3991,40 +4019,35 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0129",
     "Description": "sub_34C300",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012a",
     "ReturnType": "void",
     "Name": "FUNCTION_012A",
     "Description": "sub_34C3C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012b",
     "ReturnType": "int",
     "Name": "FUNCTION_012B",
     "Description": "sub_2BFC60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012c",
     "ReturnType": "int",
     "Name": "FUNCTION_012C",
     "Description": "sub_2BFCB0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012d",
     "ReturnType": "int",
     "Name": "FUNCTION_012D",
     "Description": "sub_2BFD00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012e",
@@ -4057,8 +4080,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0130",
     "Description": "sub_1BD790",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0131",
@@ -4110,6 +4132,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0134"
     ]
   },
   {
@@ -4123,6 +4148,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0135"
     ]
   },
   {
@@ -4130,8 +4158,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0136",
     "Description": "sub_1661C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0137",
@@ -4249,24 +4276,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_013E",
     "Description": "sub_2C1C10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x013f",
     "ReturnType": "void",
     "Name": "FUNCTION_013F",
     "Description": "sub_2C1880",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0140",
     "ReturnType": "int",
     "Name": "FUNCTION_0140",
     "Description": "sub_2C3C40",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0141",
@@ -4279,6 +4303,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0141"
     ]
   },
   {
@@ -4286,8 +4313,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0142",
     "Description": "sub_167410",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0143",
@@ -4328,6 +4354,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0144"
     ]
   },
   {
@@ -4335,24 +4364,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0145",
     "Description": "sub_1686A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0146",
     "ReturnType": "void",
     "Name": "FUNCTION_0146",
     "Description": "None",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0147",
     "ReturnType": "void",
     "Name": "FUNCTION_0147",
     "Description": "None",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0148",
@@ -4377,23 +4403,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0149",
     "Description": "sub_2C48E0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014a",
     "ReturnType": "void",
     "Name": "FUNCTION_014A",
     "Description": "sub_2C4920",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014b",
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_014B",
     "Description": "sub_34B950",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_014B"
     ]
   },
   {
@@ -4401,7 +4427,9 @@
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_014C",
     "Description": "sub_34B9D0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_014C"
     ]
   },
   {
@@ -4409,8 +4437,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_014D",
     "Description": "sub_34BB10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014e",
@@ -4822,6 +4849,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0165"
     ]
   },
   {
@@ -4883,24 +4913,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0169",
     "Description": "sub_1BD180",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016a",
     "ReturnType": "void",
     "Name": "FUNCTION_016A",
     "Description": "sub_40F350",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016b",
     "ReturnType": "void",
     "Name": "FUNCTION_016B",
     "Description": "sub_40F3A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016c",
@@ -4998,6 +5025,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0171"
     ]
   },
   {
@@ -5005,8 +5035,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0172",
     "Description": "sub_34C370",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0173",
@@ -5026,8 +5055,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0174",
     "Description": "sub_1BEE00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0175",
@@ -5047,8 +5075,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0176",
     "Description": "sub_2C49B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0177",
@@ -5073,8 +5100,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0178",
     "Description": "sub_1BEE30",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0179",
@@ -5094,8 +5120,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_017A",
     "Description": "sub_2C4B30",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017b",
@@ -5134,6 +5159,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_017D"
     ]
   },
   {
@@ -5141,24 +5169,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_017E",
     "Description": "sub_40F690",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017f",
     "ReturnType": "void",
     "Name": "FUNCTION_017F",
     "Description": "sub_2C4C00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0180",
     "ReturnType": "void",
     "Name": "FUNCTION_0180",
     "Description": "sub_2C4C40",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0181",
@@ -5171,6 +5196,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0181"
     ]
   },
   {
@@ -5178,8 +5206,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0182",
     "Description": "sub_2C4CC0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0183",
@@ -5318,8 +5345,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_018C",
     "Description": "sub_17CCE0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018d",
@@ -5344,24 +5370,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_018E",
     "Description": "sub_1BF060",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018f",
     "ReturnType": "void",
     "Name": "FUNCTION_018F",
     "Description": "sub_184A20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0190",
     "ReturnType": "void",
     "Name": "FUNCTION_0190",
     "Description": "sub_184A50",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0191",
@@ -5531,16 +5554,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_019C",
     "Description": "sub_2C2F60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x019d",
     "ReturnType": "int",
     "Name": "FUNCTION_019D",
     "Description": "sub_2C4D20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x019e",
@@ -5598,16 +5619,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A0",
     "Description": "sub_1BD1C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a1",
     "ReturnType": "int",
     "Name": "FUNCTION_01A1",
     "Description": "sub_40F240",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a2",
@@ -5627,24 +5646,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A3",
     "Description": "sub_40F7F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a4",
     "ReturnType": "int",
     "Name": "FUNCTION_01A4",
     "Description": "sub_40F860",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a5",
     "ReturnType": "int",
     "Name": "FUNCTION_01A5",
     "Description": "sub_40F8B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a6",
@@ -5664,8 +5680,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A7",
     "Description": "sub_40F970",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a8",
@@ -5685,7 +5700,9 @@
     "ReturnType": "void",
     "Name": "COMU_FUNCTION_01A9",
     "Description": "sub_34C600",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01A9"
     ]
   },
   {
@@ -5699,6 +5716,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01AA"
     ]
   },
   {
@@ -5706,8 +5726,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01AB",
     "Description": "sub_10B9C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ac",
@@ -5732,8 +5751,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01AD",
     "Description": "None",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ae",
@@ -5781,16 +5799,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01B0",
     "Description": "sub_2C4D70",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b1",
     "ReturnType": "void",
     "Name": "FUNCTION_01B1",
     "Description": "sub_2C4DE0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b2",
@@ -5942,32 +5958,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01B7",
     "Description": "sub_2C5240",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b8",
     "ReturnType": "void",
     "Name": "FUNCTION_01B8",
     "Description": "sub_2C5280",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b9",
     "ReturnType": "void",
     "Name": "FUNCTION_01B9",
     "Description": "sub_2C52D0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ba",
     "ReturnType": "void",
     "Name": "FUNCTION_01BA",
     "Description": "sub_2C5310",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01bb",
@@ -6036,7 +6048,9 @@
     "ReturnType": "void",
     "Name": "CALL_NAME_ENTRY",
     "Description": "sub_44A310",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01BF"
     ]
   },
   {
@@ -6044,8 +6058,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01C0",
     "Description": "sub_44A3C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c1",
@@ -6065,32 +6078,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01C2",
     "Description": "sub_272940",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c3",
     "ReturnType": "void",
     "Name": "FUNCTION_01C3",
     "Description": "sub_272970",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c4",
     "ReturnType": "void",
     "Name": "FUNCTION_01C4",
     "Description": "sub_2C4CF0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c5",
     "ReturnType": "int",
     "Name": "FUNCTION_01C5",
     "Description": "sub_2C4C80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c6",
@@ -6141,16 +6150,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01C9",
     "Description": "sub_2C2010",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ca",
     "ReturnType": "int",
     "Name": "FUNCTION_01CA",
     "Description": "sub_2C2060",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01cb",
@@ -6227,8 +6234,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01D0",
     "Description": "sub_1BE700",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d1",
@@ -6289,7 +6295,9 @@
     "ReturnType": "void",
     "Name": "EDSR_FUNCTION_01D4",
     "Description": "sub_270590",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01D4"
     ]
   },
   {
@@ -6323,24 +6331,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01D7",
     "Description": "sub_40F600",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d8",
     "ReturnType": "void",
     "Name": "FUNCTION_01D8",
     "Description": "sub_40F650",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d9",
     "ReturnType": "void",
     "Name": "FUNCTION_01D9",
     "Description": "sub_1BE910",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01da",
@@ -6419,23 +6424,23 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01DE",
     "Description": "sub_2C0590",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01df",
     "ReturnType": "void",
     "Name": "FUNCTION_01DF",
     "Description": "sub_2C4A70",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e0",
     "ReturnType": "void",
     "Name": "GAME_CLEAR_FUNCTION_01E0",
     "Description": "sub_184FB0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01E0"
     ]
   },
   {
@@ -6443,16 +6448,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E1",
     "Description": "sub_185040",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e2",
     "ReturnType": "int",
     "Name": "FUNCTION_01E2",
     "Description": "sub_1BEBF0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e3",
@@ -6477,8 +6480,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E4",
     "Description": "sub_1BD5F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e5",
@@ -6498,23 +6500,20 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E6",
     "Description": "sub_40F2B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e7",
     "ReturnType": "void",
     "Name": "FUNCTION_01E7",
     "Description": "sub_1BF3F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e8",
     "ReturnType": "int",
     "Name": "FUNCTION_01E8",
     "Description": "sub_1BF440",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3FES/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3FES/Modules/Common/Functions.json
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,7 +21,9 @@
     "ReturnType": "void",
     "Name": "OPEN_MSG_WIN",
     "Description": "003A27F0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0001"
     ]
   },
   {
@@ -26,7 +31,9 @@
     "ReturnType": "void",
     "Name": "CLOSE_MSG_WIN",
     "Description": "003A2860",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -41,6 +48,9 @@
         "Description": "",
         "Semantic": "SelId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -48,16 +58,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0004",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0005",
     "ReturnType": "void",
     "Name": "FUNCTION_0005",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0006",
@@ -70,6 +78,9 @@
         "Name": "mask",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0006"
     ]
   },
   {
@@ -84,6 +95,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0007"
     ]
   },
   {
@@ -98,6 +112,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0008"
     ]
   },
   {
@@ -112,6 +129,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -132,8 +152,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_000B",
     "Description": "0035AF00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x000c",
@@ -177,6 +196,9 @@
         "Name": "param2",
         "Description": "Length of fade?"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000E"
     ]
   },
   {
@@ -225,6 +247,9 @@
         "Name": "param8",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000F"
     ]
   },
   {
@@ -238,6 +263,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0010"
     ]
   },
   {
@@ -245,8 +273,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0011",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0012",
@@ -259,6 +286,9 @@
         "Name": "message",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0012"
     ]
   },
   {
@@ -339,6 +369,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0017"
     ]
   },
   {
@@ -414,6 +447,9 @@
         "Name": "type",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_001C"
     ]
   },
   {
@@ -504,6 +540,9 @@
         "Name": "param4",
         "Description": "Maybe rotation of camera?"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0021"
     ]
   },
   {
@@ -511,8 +550,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0022",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0023",
@@ -565,6 +603,9 @@
         "Description": "Index/name of msg to display",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0026"
     ]
   },
   {
@@ -579,6 +620,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0027"
     ]
   },
   {
@@ -597,6 +641,9 @@
         "Name": "selection",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0028"
     ]
   },
   {
@@ -623,6 +670,9 @@
         "Name": "FacilityID",
         "Description": "To do: Make this an enum"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002A"
     ]
   },
   {
@@ -630,16 +680,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002B",
     "Description": "0040CBE0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002c",
     "ReturnType": "void",
     "Name": "FUNCTION_002C",
     "Description": "0040CC90",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002d",
@@ -690,8 +738,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0030",
     "Description": "003110C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0031",
@@ -735,6 +782,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0033"
     ]
   },
   {
@@ -748,6 +798,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0034"
     ]
   },
   {
@@ -839,6 +892,9 @@
         "Name": "param1",
         "Description": "True if int is equal to or less than the number of allies present"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003B"
     ]
   },
   {
@@ -852,6 +908,9 @@
         "Name": "param1",
         "Description": "True if int is equal to or less than the number of enemies present"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003C"
     ]
   },
   {
@@ -865,6 +924,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003D"
     ]
   },
   {
@@ -878,6 +940,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003E"
     ]
   },
   {
@@ -891,6 +956,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003F"
     ]
   },
   {
@@ -904,6 +972,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0040"
     ]
   },
   {
@@ -917,6 +988,9 @@
         "Name": "enemy_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0041"
     ]
   },
   {
@@ -930,6 +1004,9 @@
         "Name": "Unit",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0042"
     ]
   },
   {
@@ -943,6 +1020,9 @@
         "Name": "Effect",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0043"
     ]
   },
   {
@@ -956,6 +1036,9 @@
         "Name": "Effect",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0044"
     ]
   },
   {
@@ -963,24 +1046,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0045",
     "Description": "002C8260",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0046",
     "ReturnType": "int",
     "Name": "FUNCTION_0046",
     "Description": "002C82B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0047",
     "ReturnType": "int",
     "Name": "FUNCTION_0047",
     "Description": "002C8300",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0048",
@@ -1058,6 +1138,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_004D"
     ]
   },
   {
@@ -1084,6 +1167,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_004F"
     ]
   },
   {
@@ -1110,6 +1196,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0051"
     ]
   },
   {
@@ -1214,6 +1303,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0059"
     ]
   },
   {
@@ -1221,24 +1313,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_005A",
     "Description": "002C8FB0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005b",
     "ReturnType": "int",
     "Name": "FUNCTION_005B",
     "Description": "002C9000",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005c",
     "ReturnType": "int",
     "Name": "FUNCTION_005C",
     "Description": "002C9050",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005d",
@@ -1271,7 +1360,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_RND",
     "Description": "002CC330",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_005F"
     ]
   },
   {
@@ -1279,24 +1370,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0060",
     "Description": "002CC3A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0061",
     "ReturnType": "void",
     "Name": "FUNCTION_0061",
     "Description": "002CC410",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0062",
     "ReturnType": "void",
     "Name": "FUNCTION_0062",
     "Description": "002CC480",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0063",
@@ -1309,6 +1397,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0063"
     ]
   },
   {
@@ -1322,6 +1413,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0064"
     ]
   },
   {
@@ -1335,6 +1429,9 @@
         "Name": "enemy_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0065"
     ]
   },
   {
@@ -1342,7 +1439,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_SELF",
     "Description": "002CC700",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0066"
     ]
   },
   {
@@ -1350,8 +1449,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0067",
     "Description": "002CC770",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0068",
@@ -1364,6 +1462,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0068"
     ]
   },
   {
@@ -1377,6 +1478,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0069"
     ]
   },
   {
@@ -1386,10 +1490,13 @@
     "Description": "002CC940",
     "Parameters": [
       {
-		"Type": "Affinity",
+        "Type": "Affinity",
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_006A"
     ]
   },
   {
@@ -1403,6 +1510,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_006B"
     ]
   },
   {
@@ -1462,7 +1572,9 @@
     "ReturnType": "void",
     "Name": "AI_ACT_WEAPON",
     "Description": "002C7250",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0070"
     ]
   },
   {
@@ -1476,6 +1588,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0071"
     ]
   },
   {
@@ -1483,7 +1598,9 @@
     "ReturnType": "void",
     "Name": "AI_ASK_TO_LEAVE",
     "Description": "002C73B0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0072"
     ]
   },
   {
@@ -1491,7 +1608,9 @@
     "ReturnType": "void",
     "Name": "AI_ACT_WAIT",
     "Description": "002C73F0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0073"
     ]
   },
   {
@@ -1512,8 +1631,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0075",
     "Description": "002D1310",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0076",
@@ -1536,6 +1654,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0076"
     ]
   },
   {
@@ -1549,6 +1670,9 @@
         "Name": "index",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0077"
     ]
   },
   {
@@ -1562,6 +1686,9 @@
         "Name": "id",
         "Description": "ID of floor"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0078"
     ]
   },
   {
@@ -1587,7 +1714,9 @@
     "ReturnType": "void",
     "Name": "NEXT_DAY",
     "Description": "Goes to next day",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_007A"
     ]
   },
   {
@@ -1627,6 +1756,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_007D"
     ]
   },
   {
@@ -1634,15 +1766,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_007E",
     "Description": "001C2720",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x007f",
     "ReturnType": "void",
     "Name": "FADE_SYNC",
     "Description": "Waits for fade function to catch up",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_007F"
     ]
   },
   {
@@ -1650,7 +1783,9 @@
     "ReturnType": "int",
     "Name": "GET_MONTH",
     "Description": "Returns current month",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0080"
     ]
   },
   {
@@ -1658,7 +1793,9 @@
     "ReturnType": "int",
     "Name": "GET_DAY_OF_MONTH",
     "Description": "Returns current day of the month",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0081"
     ]
   },
   {
@@ -1666,7 +1803,9 @@
     "ReturnType": "int",
     "Name": "GET_DAY_OF_WEEK",
     "Description": "Returns the current day of the week.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0082"
     ]
   },
   {
@@ -1674,8 +1813,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0083",
     "Description": "001C28F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0084",
@@ -1703,6 +1841,9 @@
         "Name": "day2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0084"
     ]
   },
   {
@@ -1721,6 +1862,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0085"
     ]
   },
   {
@@ -1769,8 +1913,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0088",
     "Description": "001C2A70",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0089",
@@ -1803,6 +1946,9 @@
         "Name": "param5",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0089"
     ]
   },
   {
@@ -1810,7 +1956,9 @@
     "ReturnType": "int",
     "Name": "GET_FLOOR_ID",
     "Description": "Gets ID of current floor. 0 if not in dungeon",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_008A"
     ]
   },
   {
@@ -1818,23 +1966,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_008B",
     "Description": "002CCD60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008c",
     "ReturnType": "void",
     "Name": "FUNCTION_008C",
     "Description": "002CCDD0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008d",
     "ReturnType": "void",
     "Name": "STAND",
     "Description": "002CCE40",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_008D"
     ]
   },
   {
@@ -1842,15 +1990,16 @@
     "ReturnType": "int",
     "Name": "FUNCTION_008E",
     "Description": "002C9200",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008f",
     "ReturnType": "int",
     "Name": "AI_CHK_ONE_MORE",
     "Description": "002C9250",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_008F"
     ]
   },
   {
@@ -1858,8 +2007,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0090",
     "Description": "002C75C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0091",
@@ -1884,16 +2032,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0092",
     "Description": "00350100",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0093",
     "ReturnType": "void",
     "Name": "FUNCTION_0093",
     "Description": "003111E0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0094",
@@ -1906,6 +2052,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0094"
     ]
   },
   {
@@ -1919,6 +2068,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0095"
     ]
   },
   {
@@ -1932,6 +2084,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0096"
     ]
   },
   {
@@ -1945,6 +2100,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0097"
     ]
   },
   {
@@ -1958,6 +2116,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0098"
     ]
   },
   {
@@ -1971,6 +2132,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0099"
     ]
   },
   {
@@ -1984,6 +2148,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_009A"
     ]
   },
   {
@@ -1997,6 +2164,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_009B"
     ]
   },
   {
@@ -2010,6 +2180,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_009C"
     ]
   },
   {
@@ -2139,8 +2312,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00A6",
     "Description": "0027D830",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a7",
@@ -2158,6 +2330,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00A7"
     ]
   },
   {
@@ -2176,6 +2351,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00A8"
     ]
   },
   {
@@ -2212,6 +2390,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00AA"
     ]
   },
   {
@@ -2248,6 +2429,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00AC"
     ]
   },
   {
@@ -2266,6 +2450,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00AD"
     ]
   },
   {
@@ -2284,6 +2471,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00AE"
     ]
   },
   {
@@ -2302,6 +2492,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00AF"
     ]
   },
   {
@@ -2364,6 +2557,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00B3"
     ]
   },
   {
@@ -2371,7 +2567,9 @@
     "ReturnType": "void",
     "Name": "APPOINT",
     "Description": "002CD430",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00B4"
     ]
   },
   {
@@ -2379,8 +2577,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00B5",
     "Description": "0035F6A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b6",
@@ -2423,6 +2620,9 @@
         "Name": "param7",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00B6"
     ]
   },
   {
@@ -2449,6 +2649,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00B8"
     ]
   },
   {
@@ -2474,16 +2677,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00BA",
     "Description": "0035F110",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bb",
     "ReturnType": "int",
     "Name": "FUNCTION_00BB",
     "Description": "0035F260",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bc",
@@ -2541,16 +2742,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00BE",
     "Description": "00423B50",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bf",
     "ReturnType": "void",
     "Name": "FUNCTION_00BF",
     "Description": "00423B60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00c0",
@@ -2576,6 +2775,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00C1"
     ]
   },
   {
@@ -2589,6 +2791,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00C2"
     ]
   },
   {
@@ -2602,6 +2807,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00C3"
     ]
   },
   {
@@ -2615,6 +2823,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00C4"
     ]
   },
   {
@@ -2685,6 +2896,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00C9"
     ]
   },
   {
@@ -2788,6 +3002,9 @@
         "Name": "amount",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00CF"
     ]
   },
   {
@@ -2806,6 +3023,9 @@
         "Name": "amount",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D0"
     ]
   },
   {
@@ -2813,7 +3033,9 @@
     "ReturnType": "int",
     "Name": "GET_YEN",
     "Description": "Returns how much yen you have.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00D1"
     ]
   },
   {
@@ -2827,6 +3049,9 @@
         "Name": "Amount",
         "Description": "Amount to give to player"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D2"
     ]
   },
   {
@@ -2840,6 +3065,9 @@
         "Name": "Amount",
         "Description": "Amount of yen to remove"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D3"
     ]
   },
   {
@@ -2853,6 +3081,9 @@
         "Name": "slot",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D4"
     ]
   },
   {
@@ -2866,6 +3097,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00D5"
     ]
   },
   {
@@ -2873,16 +3107,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00D6",
     "Description": "001C2620",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00d7",
     "ReturnType": "int",
     "Name": "FUNCTION_00D7",
     "Description": "001C3930",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00d8",
@@ -2931,6 +3163,9 @@
         "Name": "SLID",
         "Description": "A numeric id for the social link."
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DA"
     ]
   },
   {
@@ -2944,6 +3179,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DB"
     ]
   },
   {
@@ -2957,6 +3195,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DC"
     ]
   },
   {
@@ -2970,6 +3211,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00DD"
     ]
   },
   {
@@ -2977,15 +3221,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00DE",
     "Description": "0035F630",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00df",
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_00DF",
     "Description": "0035FCB0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00DF"
     ]
   },
   {
@@ -2999,6 +3244,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E0"
     ]
   },
   {
@@ -3012,6 +3260,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E1"
     ]
   },
   {
@@ -3019,55 +3270,51 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00E2",
     "Description": "001C3A20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e3",
     "ReturnType": "int",
     "Name": "FUNCTION_00E3",
     "Description": "001C3A50",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e4",
     "ReturnType": "int",
     "Name": "FUNCTION_00E4",
     "Description": "001C3B80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e5",
     "ReturnType": "int",
     "Name": "FUNCTION_00E5",
     "Description": "001C3C10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e6",
     "ReturnType": "int",
     "Name": "FUNCTION_00E6",
     "Description": "001C3C40",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e7",
     "ReturnType": "void",
     "Name": "FUNCTION_00E7",
     "Description": "001C3C70",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00e8",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_00E8",
     "Description": "001C3CA0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00E8"
     ]
   },
   {
@@ -3081,6 +3328,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00E9"
     ]
   },
   {
@@ -3099,6 +3349,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00EA"
     ]
   },
   {
@@ -3112,6 +3365,9 @@
         "Name": "param1",
         "Description": "Item ID"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00EB"
     ]
   },
   {
@@ -3143,6 +3399,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00ED"
     ]
   },
   {
@@ -3156,6 +3415,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00EE"
     ]
   },
   {
@@ -3169,6 +3431,9 @@
         "Name": "skillID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00EF"
     ]
   },
   {
@@ -3182,6 +3447,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F0"
     ]
   },
   {
@@ -3195,6 +3463,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F1"
     ]
   },
   {
@@ -3208,6 +3479,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F2"
     ]
   },
   {
@@ -3221,6 +3495,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F3"
     ]
   },
   {
@@ -3234,6 +3511,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F4"
     ]
   },
   {
@@ -3247,6 +3527,9 @@
         "Name": "affinityID",
         "Description": "Not certain on the difference between this and AI_EN_WEAK"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F5"
     ]
   },
   {
@@ -3260,6 +3543,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F6"
     ]
   },
   {
@@ -3273,6 +3559,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00F7"
     ]
   },
   {
@@ -3322,6 +3611,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00FA"
     ]
   },
   {
@@ -3340,6 +3632,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00FB"
     ]
   },
   {
@@ -3358,6 +3653,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00FC"
     ]
   },
   {
@@ -3371,6 +3669,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00FD"
     ]
   },
   {
@@ -3396,8 +3697,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00FF",
     "Description": "002CE430",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0100",
@@ -3410,6 +3710,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0100"
     ]
   },
   {
@@ -3423,6 +3726,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0101"
     ]
   },
   {
@@ -3436,6 +3742,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0102"
     ]
   },
   {
@@ -3449,6 +3758,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0103"
     ]
   },
   {
@@ -3462,6 +3774,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0104"
     ]
   },
   {
@@ -3475,6 +3790,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0105"
     ]
   },
   {
@@ -3488,6 +3806,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0106"
     ]
   },
   {
@@ -3537,6 +3858,9 @@
         "Name": "number",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0109"
     ]
   },
   {
@@ -3560,6 +3884,9 @@
         "Name": "number",
         "Description": "Redundant in most cases as the party lacks access to items that heal 2+ allies"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_010A"
     ]
   },
   {
@@ -3590,8 +3917,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_010C",
     "Description": "002CFE00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x010d",
@@ -3611,16 +3937,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_010E",
     "Description": "002D00A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x010f",
     "ReturnType": "int",
     "Name": "FUNCTION_010F",
     "Description": "002D01C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0110",
@@ -3666,7 +3990,9 @@
     "ReturnType": "int",
     "Name": "AI_WEAPON_AFFINITY",
     "Description": "002CF940",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0113"
     ]
   },
   {
@@ -3680,6 +4006,9 @@
         "Name": "index",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0114"
     ]
   },
   {
@@ -3698,6 +4027,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0115"
     ]
   },
   {
@@ -3705,8 +4037,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0116",
     "Description": "001C3BB0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0117",
@@ -3724,6 +4055,9 @@
         "Name": "hp",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0117"
     ]
   },
   {
@@ -3742,6 +4076,9 @@
         "Name": "sp",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0118"
     ]
   },
   {
@@ -3773,6 +4110,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_011A"
     ]
   },
   {
@@ -3796,6 +4136,9 @@
         "Name": "amount",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_011B"
     ]
   },
   {
@@ -3827,6 +4170,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_011D"
     ]
   },
   {
@@ -3840,6 +4186,9 @@
         "Name": "enemy_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_011E"
     ]
   },
   {
@@ -3884,6 +4233,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0121"
     ]
   },
   {
@@ -3902,6 +4254,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0122"
     ]
   },
   {
@@ -3928,6 +4283,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0124"
     ]
   },
   {
@@ -3941,6 +4299,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0125"
     ]
   },
   {
@@ -3997,40 +4358,35 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0129",
     "Description": "00360940",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012a",
     "ReturnType": "void",
     "Name": "FUNCTION_012A",
     "Description": "00360A00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012b",
     "ReturnType": "int",
     "Name": "FUNCTION_012B",
     "Description": "002CB950",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012c",
     "ReturnType": "int",
     "Name": "FUNCTION_012C",
     "Description": "002CB9A0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012d",
     "ReturnType": "int",
     "Name": "FUNCTION_012D",
     "Description": "002CB9F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x012e",
@@ -4063,8 +4419,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0130",
     "Description": "001C4100",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0131",
@@ -4103,6 +4458,9 @@
         "Name": "range",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0133"
     ]
   },
   {
@@ -4116,6 +4474,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0134"
     ]
   },
   {
@@ -4129,6 +4490,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0135"
     ]
   },
   {
@@ -4136,8 +4500,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0136",
     "Description": "00167C40",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0137",
@@ -4168,6 +4531,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0138"
     ]
   },
   {
@@ -4248,6 +4614,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_013D"
     ]
   },
   {
@@ -4255,15 +4624,16 @@
     "ReturnType": "int",
     "Name": "FUNCTION_013E",
     "Description": "002CD960",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x013f",
     "ReturnType": "void",
     "Name": "AI_0013F",
     "Description": "002CD570",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_013F"
     ]
   },
   {
@@ -4271,8 +4641,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0140",
     "Description": "002CF990",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0141",
@@ -4285,6 +4654,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0141"
     ]
   },
   {
@@ -4292,8 +4664,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0142",
     "Description": "00168E90",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0143",
@@ -4334,6 +4705,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0144"
     ]
   },
   {
@@ -4341,24 +4715,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0145",
     "Description": "0016A120",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0146",
     "ReturnType": "void",
     "Name": "FUNCTION_0146",
     "Description": "0016E600",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0147",
     "ReturnType": "void",
     "Name": "FUNCTION_0147",
     "Description": "0016E660",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0148",
@@ -4383,23 +4754,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0149",
     "Description": "Likely the function that splits Arcana Justice and Chariot",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014a",
     "ReturnType": "void",
     "Name": "FUNCTION_014A",
     "Description": "002D0670",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014b",
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_014B",
     "Description": "0035FF90",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_014B"
     ]
   },
   {
@@ -4407,7 +4778,9 @@
     "ReturnType": "int",
     "Name": "COMU_FUNCTION_014C",
     "Description": "00360010",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_014C"
     ]
   },
   {
@@ -4415,8 +4788,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_014D",
     "Description": "00360150",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x014e",
@@ -4563,6 +4935,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0156"
     ]
   },
   {
@@ -4586,6 +4961,9 @@
         "Name": "statusID",
         "Description": "Status effect"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0157"
     ]
   },
   {
@@ -4658,6 +5036,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_015B"
     ]
   },
   {
@@ -4828,6 +5209,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0165"
     ]
   },
   {
@@ -4882,6 +5266,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0168"
     ]
   },
   {
@@ -4889,24 +5276,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0169",
     "Description": "001C3AF0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016a",
     "ReturnType": "void",
     "Name": "FUNCTION_016A",
     "Description": "00424700",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016b",
     "ReturnType": "void",
     "Name": "FUNCTION_016B",
     "Description": "00424750",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x016c",
@@ -5004,6 +5388,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0171"
     ]
   },
   {
@@ -5011,8 +5398,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0172",
     "Description": "003609B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0173",
@@ -5032,8 +5418,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0174",
     "Description": "001C5810",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0175",
@@ -5053,8 +5438,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0176",
     "Description": "002D07B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0177",
@@ -5072,6 +5456,9 @@
         "Name": "Skill",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0177"
     ]
   },
   {
@@ -5079,8 +5466,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0178",
     "Description": "001C5840",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0179",
@@ -5100,8 +5486,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_017A",
     "Description": "002D0A10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017b",
@@ -5140,6 +5525,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_017D"
     ]
   },
   {
@@ -5147,24 +5535,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_017E",
     "Description": "00424A40",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x017f",
     "ReturnType": "void",
     "Name": "FUNCTION_017F",
     "Description": "002D0AE0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0180",
     "ReturnType": "void",
     "Name": "FUNCTION_0180",
     "Description": "002D0B20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0181",
@@ -5177,6 +5562,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0181"
     ]
   },
   {
@@ -5184,8 +5572,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0182",
     "Description": "002D0BA0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0183",
@@ -5203,6 +5590,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0183"
     ]
   },
   {
@@ -5229,6 +5619,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0185"
     ]
   },
   {
@@ -5324,7 +5717,9 @@
     "ReturnType": "void",
     "Name": "SOFT_RESET",
     "Description": "Brings game back to title screen",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_018C"
     ]
   },
   {
@@ -5350,24 +5745,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_018E",
     "Description": "001C5A70",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x018f",
     "ReturnType": "void",
     "Name": "FUNCTION_018F",
     "Description": "001883C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0190",
     "ReturnType": "void",
     "Name": "FUNCTION_0190",
     "Description": "00188410",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0191",
@@ -5452,6 +5844,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0195"
     ]
   },
   {
@@ -5491,6 +5886,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0198"
     ]
   },
   {
@@ -5517,6 +5915,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_019A"
     ]
   },
   {
@@ -5530,6 +5931,9 @@
         "Name": "effectID",
         "Description": "Returns -1 if buff/ debuff is active, else the position of a suitable target"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_019B"
     ]
   },
   {
@@ -5537,16 +5941,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_019C",
     "Description": "002CECB0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x019d",
     "ReturnType": "int",
     "Name": "FUNCTION_019D",
     "Description": "002D0C00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x019e",
@@ -5604,16 +6006,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A0",
     "Description": "001C3B30",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a1",
     "ReturnType": "int",
     "Name": "FUNCTION_01A1",
     "Description": "004245F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a2",
@@ -5633,24 +6033,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A3",
     "Description": "00424BA0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a4",
     "ReturnType": "int",
     "Name": "FUNCTION_01A4",
     "Description": "00424C10",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a5",
     "ReturnType": "int",
     "Name": "FUNCTION_01A5",
     "Description": "00424C60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a6",
@@ -5670,8 +6067,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01A7",
     "Description": "00424D20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01a8",
@@ -5691,7 +6087,9 @@
     "ReturnType": "void",
     "Name": "COMU_FUNCTION_01A9",
     "Description": "00360C40",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01A9"
     ]
   },
   {
@@ -5705,6 +6103,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01AA"
     ]
   },
   {
@@ -5712,7 +6113,9 @@
     "ReturnType": "void",
     "Name": "NS_MOVIE_SYNC",
     "Description": "Always called after CALL_MOVIE.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01AB"
     ]
   },
   {
@@ -5731,6 +6134,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01AC"
     ]
   },
   {
@@ -5738,8 +6144,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01AD",
     "Description": "002D14B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ae",
@@ -5787,16 +6192,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01B0",
     "Description": "002D0C50",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b1",
     "ReturnType": "void",
     "Name": "FUNCTION_01B1",
     "Description": "002D0CC0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b2",
@@ -5948,32 +6351,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01B7",
     "Description": "002D1120",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b8",
     "ReturnType": "void",
     "Name": "FUNCTION_01B8",
     "Description": "002D1160",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01b9",
     "ReturnType": "void",
     "Name": "FUNCTION_01B9",
     "Description": "002D11B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ba",
     "ReturnType": "void",
     "Name": "FUNCTION_01BA",
     "Description": "002D11F0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01bb",
@@ -5986,6 +6385,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01BB"
     ]
   },
   {
@@ -5999,6 +6401,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01BC"
     ]
   },
   {
@@ -6042,7 +6447,9 @@
     "ReturnType": "void",
     "Name": "CALL_NAME_ENTRY",
     "Description": "0045F6E0",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01BF"
     ]
   },
   {
@@ -6050,8 +6457,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01C0",
     "Description": "0045F790",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c1",
@@ -6071,32 +6477,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01C2",
     "Description": "0027D910",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c3",
     "ReturnType": "void",
     "Name": "FUNCTION_01C3",
     "Description": "0027D940",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c4",
     "ReturnType": "void",
     "Name": "FUNCTION_01C4",
     "Description": "002D0BD0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c5",
     "ReturnType": "int",
     "Name": "FUNCTION_01C5",
     "Description": "002D0B60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01c6",
@@ -6127,6 +6529,9 @@
         "Name": "Effect",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01C7"
     ]
   },
   {
@@ -6140,6 +6545,9 @@
         "Name": "param1",
         "Description": "Excludes unconscious allies"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01C8"
     ]
   },
   {
@@ -6147,16 +6555,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01C9",
     "Description": "002CDD60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ca",
     "ReturnType": "int",
     "Name": "FUNCTION_01CA",
     "Description": "002CDDB0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01cb",
@@ -6182,6 +6588,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01CC"
     ]
   },
   {
@@ -6208,6 +6617,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01CE"
     ]
   },
   {
@@ -6226,6 +6638,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01CF"
     ]
   },
   {
@@ -6233,8 +6648,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01D0",
     "Description": "001C5110",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d1",
@@ -6260,6 +6674,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01D2"
     ]
   },
   {
@@ -6295,7 +6712,9 @@
     "ReturnType": "void",
     "Name": "EDSR_FUNCTION_01D4",
     "Description": "0027B560",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01D4"
     ]
   },
   {
@@ -6329,23 +6748,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01D7",
     "Description": "004249B0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d8",
     "ReturnType": "void",
     "Name": "FUNCTION_01D8",
     "Description": "00424A00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01d9",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_01D9",
     "Description": "001C5320",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01D9"
     ]
   },
   {
@@ -6418,6 +6837,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01DD"
     ]
   },
   {
@@ -6425,7 +6847,9 @@
     "ReturnType": "int",
     "Name": "AI_CHK_TURN",
     "Description": "For enemies with multiple turns, true if it is equivalent to the turn number",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01DE"
     ]
   },
   {
@@ -6433,15 +6857,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01DF",
     "Description": "002D0920",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e0",
     "ReturnType": "void",
     "Name": "GAME_CLEAR_FUNCTION_01E0",
     "Description": "00188970",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01E0"
     ]
   },
   {
@@ -6449,16 +6874,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E1",
     "Description": "00188A00",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e2",
     "ReturnType": "int",
     "Name": "FUNCTION_01E2",
     "Description": "001C5600",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e3",
@@ -6476,6 +6899,9 @@
         "Name": "stat",
         "Description": "0 = academics, 1 = charm, 2 = courage"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01E3"
     ]
   },
   {
@@ -6483,8 +6909,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E4",
     "Description": "001C3F60",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e5",
@@ -6497,6 +6922,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01E5"
     ]
   },
   {
@@ -6504,32 +6932,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01E6",
     "Description": "00424660",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e7",
     "ReturnType": "void",
     "Name": "FUNCTION_01E7",
     "Description": "001C5ED0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e8",
     "ReturnType": "int",
     "Name": "FUNCTION_01E8",
     "Description": "001C5F20",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01e9",
     "ReturnType": "int",
     "Name": "FUNCTION_01E9",
     "Description": "001C6000",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ea",
@@ -6565,6 +6989,9 @@
         "Name": "time",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01EB"
     ]
   },
   {
@@ -6572,8 +6999,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01EC",
     "Description": "002D08C0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ed",
@@ -6598,8 +7024,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01EE",
     "Description": "0017F790",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01ef",
@@ -6612,6 +7037,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01EF"
     ]
   },
   {
@@ -6619,8 +7047,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01F0",
     "Description": "0035FC80",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f1",
@@ -6643,6 +7070,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01F1"
     ]
   },
   {
@@ -6650,15 +7080,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_01F2",
     "Description": "001C6050",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f3",
     "ReturnType": "void",
     "Name": "HIKITUGI_FUNCTION_01F3",
     "Description": "00193570",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_01F3"
     ]
   },
   {
@@ -6666,8 +7097,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_01F4",
     "Description": "00193600",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x01f5",
@@ -6685,6 +7115,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_01F5"
     ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/AI/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/AI/Functions.json
@@ -10,6 +10,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0000"
     ]
   },
   {
@@ -166,6 +169,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000C"
     ]
   },
   {
@@ -205,6 +211,9 @@
         "Name": "partyID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000F"
     ]
   },
   {
@@ -218,6 +227,9 @@
         "Name": "Effect",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0010"
     ]
   },
   {
@@ -231,6 +243,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0011"
     ]
   },
   {
@@ -486,6 +501,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0026"
     ]
   },
   {
@@ -540,7 +558,10 @@
     "ReturnType": "void",
     "Name": "AI_TAR_RND",
     "Description": "Address: 0x089FF0F0",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_002C"
+    ]
   },
   {
     "Index": "0x202d",
@@ -574,6 +595,9 @@
         "Name": "statusID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0030"
     ]
   },
   {
@@ -587,6 +611,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0031"
     ]
   },
   {
@@ -600,6 +627,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0032"
     ]
   },
   {
@@ -607,7 +637,10 @@
     "ReturnType": "void",
     "Name": "AI_MINE",
     "Description": "Address: 0x089FF2D0",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0033"
+    ]
   },
   {
     "Index": "0x2034",
@@ -666,6 +699,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0038"
     ]
   },
   {
@@ -725,7 +761,10 @@
     "ReturnType": "void",
     "Name": "AI_ACT_WEAPON",
     "Description": "Address: 0x089FC168",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_003D"
+    ]
   },
   {
     "Index": "0x203e",
@@ -738,6 +777,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_003E"
     ]
   },
   {
@@ -752,7 +794,10 @@
     "ReturnType": "void",
     "Name": "AI_ACT_WAIT",
     "Description": "Address: 0x089FC2AC",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0040"
+    ]
   },
   {
     "Index": "0x2041",
@@ -807,7 +852,10 @@
     "ReturnType": "int",
     "Name": "AI_CHK_ONE_MORE",
     "Description": "Address: 0x089FD0B0",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0047"
+    ]
   },
   {
     "Index": "0x2048",
@@ -1380,6 +1428,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_006F"
     ]
   },
   {
@@ -1847,6 +1898,9 @@
         "Name": "enemy_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0091"
     ]
   },
   {
@@ -1907,6 +1961,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0097"
     ]
   },
   {
@@ -2096,6 +2153,9 @@
         "Name": "effectID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00A4"
     ]
   },
   {
@@ -2204,6 +2264,9 @@
         "Name": "affinityID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00AA"
     ]
   },
   {
@@ -2286,6 +2349,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00B0"
     ]
   },
   {
@@ -2333,6 +2399,9 @@
         "Name": "skill_ID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00B5"
     ]
   },
   {
@@ -2870,6 +2939,9 @@
         "Name": "Effect",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00DB"
     ]
   },
   {
@@ -3041,7 +3113,10 @@
     "ReturnType": "int",
     "Name": "AI_CHK_TURN",
     "Description": "For enemies with multiple turns, true if it is equivalent to the turn number",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_00E8"
+    ]
   },
   {
     "Index": "0x20e9",
@@ -3412,6 +3487,9 @@
     "ReturnType": "int",
     "Name": "AI_CHK_HP_VALUE",
     "Description": "Address: 0x08A00038",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0108"
+    ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Common/Functions.json
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,14 +21,20 @@
     "ReturnType": "void",
     "Name": "MSG_WND_DSP",
     "Description": "Address: 0x08985078",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0001"
+    ]
   },
   {
     "Index": "0x0002",
     "ReturnType": "void",
     "Name": "MSG_WND_CLS",
     "Description": "Address: 0x08985470",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
+    ]
   },
   {
     "Index": "0x0003",
@@ -39,6 +48,9 @@
         "Description": "",
         "Semantic": "SelId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -46,14 +58,20 @@
     "ReturnType": "void",
     "Name": "SEL_WND_DSP",
     "Description": "Null pointer",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0004"
+    ]
   },
   {
     "Index": "0x0005",
     "ReturnType": "void",
     "Name": "SEL_WND_CLS",
     "Description": "Null pointer",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0005"
+    ]
   },
   {
     "Index": "0x0006",
@@ -80,6 +98,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0007"
     ]
   },
   {
@@ -94,6 +115,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0008"
     ]
   },
   {
@@ -108,6 +132,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -121,6 +148,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000A"
     ]
   },
   {
@@ -141,6 +171,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000C"
     ]
   },
   {
@@ -172,6 +205,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000E"
     ]
   },
   {
@@ -441,6 +477,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_001D"
     ]
   },
   {
@@ -504,6 +543,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0022"
     ]
   },
   {
@@ -517,6 +559,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0023"
     ]
   },
   {
@@ -679,6 +724,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002C"
     ]
   },
   {
@@ -705,6 +753,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002E"
     ]
   },
   {
@@ -723,6 +774,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002F"
     ]
   },
   {
@@ -769,6 +823,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0034"
     ]
   },
   {
@@ -797,6 +854,9 @@
         "Name": "param4",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0035"
     ]
   },
   {
@@ -930,6 +990,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0040"
     ]
   },
   {
@@ -943,6 +1006,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0041"
     ]
   },
   {
@@ -1186,6 +1252,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0056"
     ]
   },
   {
@@ -1379,6 +1448,9 @@
         "Name": "param7",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0064"
     ]
   },
   {
@@ -1392,6 +1464,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0065"
     ]
   },
   {
@@ -1423,6 +1498,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0067"
     ]
   },
   {
@@ -1430,7 +1508,9 @@
     "ReturnType": "int",
     "Name": "HD_FUNCTION_0068",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0068"
     ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Event/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Event/Functions.json
@@ -25,6 +25,9 @@
         "Name": "param4",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0000"
     ]
   },
   {
@@ -85,6 +88,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0006"
     ]
   },
   {
@@ -545,6 +551,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_002B"
     ]
   },
   {
@@ -1169,14 +1178,20 @@
     "ReturnType": "int",
     "Name": "FLD_GET_MAJOR",
     "Description": "Address: 0x08994F64",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "EVT_FUNCTION_0057"
+    ]
   },
   {
     "Index": "0x3058",
     "ReturnType": "int",
     "Name": "FLD_GET_MINOR",
     "Description": "Address: 0x08994FB0",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "EVT_FUNCTION_0058"
+    ]
   },
   {
     "Index": "0x3059",

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Facility/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Facility/Functions.json
@@ -15,6 +15,9 @@
         "Name": "MinorID",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FCL_FUNCTION_0000"
     ]
   },
   {
@@ -43,6 +46,9 @@
         "Name": "param4",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FCL_FUNCTION_0001"
     ]
   },
   {
@@ -50,7 +56,10 @@
     "ReturnType": "void",
     "Name": "NEXT_TIME",
     "Description": "Progresses time of day; Address: 0x08995024",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0002"
+    ]
   },
   {
     "Index": "0x4003",
@@ -63,6 +72,9 @@
         "Name": "StartingSelection",
         "Description": "Puts the cursor on given position"
       }
+    ],
+    "Aliases": [
+      "FCL_FUNCTION_0003"
     ]
   },
   {
@@ -101,28 +113,40 @@
     "ReturnType": "void",
     "Name": "CALL_TITLE",
     "Description": "Calls title screen; Address: 0x089733BC",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0006"
+    ]
   },
   {
     "Index": "0x4007",
     "ReturnType": "void",
     "Name": "CALL_NAME_ENTRY",
     "Description": "Calls Protagonist name entry screen; Address: 0x089733FC",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0007"
+    ]
   },
   {
     "Index": "0x4008",
     "ReturnType": "void",
     "Name": "SAVE_MENU",
     "Description": "Calls Save Data screen; Address: 0x08973740",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0008"
+    ]
   },
   {
     "Index": "0x4009",
     "ReturnType": "void",
     "Name": "LOAD_MENU",
     "Description": "Calls Load Data screen; Address: 0x089737A8",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0009"
+    ]
   },
   {
     "Index": "0x400a",
@@ -136,7 +160,10 @@
     "ReturnType": "void",
     "Name": "SAVE_NG_MENU",
     "Description": "Calls Save New Cycle Data screen; Address: 0x08A63E5C",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_000B"
+    ]
   },
   {
     "Index": "0x400c",
@@ -150,28 +177,40 @@
     "ReturnType": "void",
     "Name": "CALL_STAFF_ROLL",
     "Description": "Address: 0x0896F390",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_000D"
+    ]
   },
   {
     "Index": "0x400e",
     "ReturnType": "void",
     "Name": "CALL_WEAPON_SHOP",
     "Description": "Address: 0x0887262C",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_000E"
+    ]
   },
   {
     "Index": "0x400f",
     "ReturnType": "void",
     "Name": "CALL_ITEM_SHOP",
     "Description": "Address: 0x08872674",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_000F"
+    ]
   },
   {
     "Index": "0x4010",
     "ReturnType": "void",
     "Name": "CALL_COMBINE_SHOP",
     "Description": "Address: 0x08872704",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0010"
+    ]
   },
   {
     "Index": "0x4011",
@@ -184,6 +223,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FCL_FUNCTION_0011"
     ]
   },
   {
@@ -191,14 +233,20 @@
     "ReturnType": "void",
     "Name": "WAIT_BATTLE",
     "Description": "Address: 0x089BA858",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0012"
+    ]
   },
   {
     "Index": "0x4013",
     "ReturnType": "void",
     "Name": "CALL_TRADE_SHOP",
     "Description": "Address: 0x088726BC",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0013"
+    ]
   },
   {
     "Index": "0x4014",
@@ -240,7 +288,10 @@
     "ReturnType": "void",
     "Name": "CALL_DARK_HOUR",
     "Description": "Address: 0x08973D98",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_0016"
+    ]
   },
   {
     "Index": "0x4017",
@@ -268,7 +319,10 @@
     "ReturnType": "void",
     "Name": "CALL_SEX_SELECT",
     "Description": "Address: 0x08878C80",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FCL_FUNCTION_001A"
+    ]
   },
   {
     "Index": "0x401b",

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Field/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Field/Functions.json
@@ -212,6 +212,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0012"
     ]
   },
   {
@@ -1400,7 +1403,10 @@
     "ReturnType": "void",
     "Name": "CALL_CALENDAR",
     "Description": "Address: 0x089365C4",
-    "Parameters": []
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_006A"
+    ]
   },
   {
     "Index": "0x106b",
@@ -1427,7 +1433,9 @@
     "ReturnType": "void",
     "Name": "HD_FLD_FUNCTION_006D",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_006D"
     ]
   },
   {
@@ -1435,7 +1443,9 @@
     "ReturnType": "void",
     "Name": "HD_FLD_FUNCTION_006E",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_006E"
     ]
   },
   {
@@ -1443,7 +1453,9 @@
     "ReturnType": "int",
     "Name": "HD_FLD_FUNCTION_006F",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_006F"
     ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Shared/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona3Portable/Modules/Shared/Functions.json
@@ -15,6 +15,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0000"
     ]
   },
   {
@@ -59,6 +62,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0003"
     ]
   },
   {
@@ -72,6 +78,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0004"
     ]
   },
   {
@@ -90,6 +99,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0005"
     ]
   },
   {
@@ -108,6 +120,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0006"
     ]
   },
   {
@@ -131,6 +146,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0007"
     ]
   },
   {
@@ -144,6 +162,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0008"
     ]
   },
   {
@@ -157,6 +178,9 @@
         "Name": "PartyMember",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0009"
     ]
   },
   {
@@ -170,6 +194,9 @@
         "Name": "PartyMember",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_000A"
     ]
   },
   {
@@ -188,6 +215,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_000B"
     ]
   },
   {
@@ -201,6 +231,9 @@
         "Name": "PartyMember",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_000C"
     ]
   },
   {
@@ -214,6 +247,9 @@
         "Name": "PartyMember",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_000D"
     ]
   },
   {
@@ -232,6 +268,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_000E"
     ]
   },
   {
@@ -329,6 +368,9 @@
         "Name": "PartyMember",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0014"
     ]
   },
   {
@@ -342,6 +384,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0015"
     ]
   },
   {
@@ -360,6 +405,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "SHD_FUNCTION_0016"
     ]
   },
   {

--- a/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/AI/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/AI/Functions.json
@@ -10,6 +10,9 @@
         "Name": "percentage",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0000"
     ]
   },
   {
@@ -23,6 +26,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0001"
     ]
   },
   {
@@ -36,6 +42,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0002"
     ]
   },
   {
@@ -49,6 +58,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0003"
     ]
   },
   {
@@ -127,6 +139,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0009"
     ]
   },
   {
@@ -140,6 +155,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000A"
     ]
   },
   {
@@ -153,6 +171,9 @@
         "Name": "statusFlags",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000B"
     ]
   },
   {
@@ -166,6 +187,9 @@
         "Name": "statusFlags",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000C"
     ]
   },
   {
@@ -192,6 +216,9 @@
         "Name": "unitId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000E"
     ]
   },
   {
@@ -205,6 +232,9 @@
         "Name": "unitId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000F"
     ]
   },
   {
@@ -218,6 +248,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0010"
     ]
   },
   {
@@ -231,6 +264,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0011"
     ]
   },
   {
@@ -238,24 +274,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2013",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2014",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0014",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2015",
@@ -333,6 +366,9 @@
         "Name": "element",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001A"
     ]
   },
   {
@@ -359,6 +395,9 @@
         "Name": "element",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001C"
     ]
   },
   {
@@ -385,6 +424,9 @@
         "Name": "element",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001E"
     ]
   },
   {
@@ -463,6 +505,9 @@
         "Name": "skillId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0024"
     ]
   },
   {
@@ -496,24 +541,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2028",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0028",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2029",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0029",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x202a",
@@ -546,7 +588,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_RND",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_002C"
     ]
   },
   {
@@ -554,24 +598,21 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_002D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x202e",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_002E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x202f",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_002F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2030",
@@ -584,6 +625,9 @@
         "Name": "status",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0030"
     ]
   },
   {
@@ -597,6 +641,9 @@
         "Name": "status",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0031"
     ]
   },
   {
@@ -610,6 +657,9 @@
         "Name": "unitId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0032"
     ]
   },
   {
@@ -617,7 +667,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_MINE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0033"
     ]
   },
   {
@@ -625,8 +677,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2035",
@@ -737,7 +788,9 @@
     "ReturnType": "void",
     "Name": "AI_ACT_ATTACK",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_003D"
     ]
   },
   {
@@ -751,6 +804,9 @@
         "Name": "skillId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_003E"
     ]
   },
   {
@@ -758,15 +814,16 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_003F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2040",
     "ReturnType": "void",
     "Name": "AI_ACT_DEFENSE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0040"
     ]
   },
   {
@@ -787,47 +844,44 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0042",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2043",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0043",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2044",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0044",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2045",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0045",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2046",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0046",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2047",
     "ReturnType": "bool",
     "Name": "AI_CHK_MORE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0047"
     ]
   },
   {
@@ -835,7 +889,9 @@
     "ReturnType": "void",
     "Name": "AI_ACT_WAIT",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0048"
     ]
   },
   {
@@ -1080,6 +1136,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_005A"
     ]
   },
   {
@@ -1152,6 +1211,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_005E"
     ]
   },
   {
@@ -1293,8 +1355,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0067",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2068",
@@ -1591,8 +1652,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_007C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x207d",
@@ -1785,8 +1845,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0089",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208a",
@@ -1806,16 +1865,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_008B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208c",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_008C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208d",
@@ -1861,8 +1918,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0090",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2091",
@@ -1882,24 +1938,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0092",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2093",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0093",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2094",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0094",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2095",
@@ -1938,6 +1991,9 @@
         "Name": "max",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0097"
     ]
   },
   {
@@ -1951,6 +2007,9 @@
         "Name": "unitId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0098"
     ]
   },
   {
@@ -1958,24 +2017,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0099",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209a",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_009A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209b",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_009B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209c",
@@ -2088,6 +2144,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00A1"
     ]
   },
   {
@@ -2279,6 +2338,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00AD"
     ]
   },
   {
@@ -2297,6 +2359,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00AE"
     ]
   },
   {
@@ -2408,16 +2473,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00B7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20b8",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00B8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20b9",
@@ -2465,16 +2528,14 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00BB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20bc",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00BC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20bd",
@@ -2646,32 +2707,28 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c3",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c4",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c5",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c6",
@@ -2777,6 +2834,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00CC"
     ]
   },
   {
@@ -2797,16 +2857,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00CE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20cf",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00CF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20d0",
@@ -2950,8 +3008,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00D9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20da",
@@ -3002,48 +3059,42 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20de",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20df",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e0",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e1",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e2",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e3",
@@ -3081,8 +3132,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e6",
@@ -3115,8 +3165,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e9",
@@ -3375,8 +3424,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00FC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20fd",
@@ -3449,8 +3497,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00FF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2100",
@@ -3483,16 +3530,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0102",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2103",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0103",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2104",
@@ -3545,8 +3590,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0106",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2107",
@@ -3566,8 +3610,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0108",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2109",
@@ -3592,8 +3635,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_010A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x210b",
@@ -3726,15 +3768,13 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0112",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2113",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0113",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Common/Functions.json
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,7 +21,9 @@
     "ReturnType": "void",
     "Name": "MSG_WND_DSP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0001"
     ]
   },
   {
@@ -26,7 +31,9 @@
     "ReturnType": "void",
     "Name": "MSG_WND_CLS",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -41,6 +48,9 @@
         "Description": "Id of selection dialog.",
         "Semantic": "SelId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -48,16 +58,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0004",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0005",
     "ReturnType": "void",
     "Name": "FUNCTION_0005",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0006",
@@ -80,6 +88,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0006"
     ]
   },
   {
@@ -125,6 +136,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -139,6 +153,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000A"
     ]
   },
   {
@@ -153,6 +170,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000B"
     ]
   },
   {
@@ -167,6 +187,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000C"
     ]
   },
   {
@@ -200,8 +223,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_000F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0010",
@@ -214,6 +236,9 @@
         "Name": "time",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0010"
     ]
   },
   {
@@ -253,6 +278,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0013"
     ]
   },
   {
@@ -266,6 +294,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0014"
     ]
   },
   {
@@ -279,6 +310,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0015"
     ]
   },
   {
@@ -297,6 +331,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0016"
     ]
   },
   {
@@ -304,8 +341,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0018",
@@ -371,6 +407,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0019"
     ]
   },
   {
@@ -448,8 +487,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0020",
@@ -573,6 +611,9 @@
         "Name": "mask",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0025"
     ]
   },
   {
@@ -690,40 +731,35 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002c",
     "ReturnType": "void",
     "Name": "FUNCTION_002C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002d",
     "ReturnType": "void",
     "Name": "FUNCTION_002D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002e",
     "ReturnType": "void",
     "Name": "FUNCTION_002E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002f",
     "ReturnType": "void",
     "Name": "FUNCTION_002F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0030",
@@ -751,6 +787,9 @@
         "Name": "param4",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0030"
     ]
   },
   {
@@ -802,6 +841,9 @@
         "Name": "sub",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0032"
     ]
   },
   {
@@ -809,32 +851,28 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0034",
     "ReturnType": "int",
     "Name": "FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0035",
     "ReturnType": "int",
     "Name": "FUNCTION_0035",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0036",
     "ReturnType": "int",
     "Name": "FUNCTION_0036",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0037",
@@ -852,6 +890,9 @@
         "Name": "day",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0037"
     ]
   },
   {
@@ -865,6 +906,9 @@
         "Name": "charId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0038"
     ]
   },
   {
@@ -878,6 +922,9 @@
         "Name": "charId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0039"
     ]
   },
   {
@@ -885,8 +932,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x003b",
@@ -899,6 +945,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003B"
     ]
   },
   {
@@ -906,7 +955,9 @@
     "ReturnType": "void",
     "Name": "CALL_TV",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_003C"
     ]
   },
   {
@@ -961,6 +1012,9 @@
         "Name": "floor",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003F"
     ]
   },
   {
@@ -1007,6 +1061,9 @@
         "Name": "effectId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0041"
     ]
   },
   {
@@ -1025,6 +1082,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0042"
     ]
   },
   {
@@ -1056,6 +1116,9 @@
         "Name": "paramId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0044"
     ]
   },
   {
@@ -1127,15 +1190,16 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0048",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0049",
     "ReturnType": "void",
     "Name": "CALL_WEAPON_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0049"
     ]
   },
   {
@@ -1143,7 +1207,9 @@
     "ReturnType": "void",
     "Name": "CALL_ITEM_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004A"
     ]
   },
   {
@@ -1151,7 +1217,9 @@
     "ReturnType": "void",
     "Name": "CALL_COMBINE_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004B"
     ]
   },
   {
@@ -1159,31 +1227,30 @@
     "ReturnType": "int",
     "Name": "FUNCTION_004C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004d",
     "ReturnType": "void",
     "Name": "FUNCTION_004D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004e",
     "ReturnType": "int",
     "Name": "FUNCTION_004E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004f",
     "ReturnType": "void",
     "Name": "CALL_TITLE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004F"
     ]
   },
   {
@@ -1197,6 +1264,9 @@
         "Name": "amount",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0050"
     ]
   },
   {
@@ -1204,7 +1274,9 @@
     "ReturnType": "void",
     "Name": "CALL_NAME_ENTRY",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0051"
     ]
   },
   {
@@ -1218,6 +1290,9 @@
         "Name": "amount",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0052"
     ]
   },
   {
@@ -1284,32 +1359,28 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0056",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0057",
     "ReturnType": "int",
     "Name": "FUNCTION_0057",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0058",
     "ReturnType": "int",
     "Name": "FUNCTION_0058",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0059",
     "ReturnType": "void",
     "Name": "FUNCTION_0059",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x005a",
@@ -1477,6 +1548,9 @@
         "Name": "movieId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0064"
     ]
   },
   {
@@ -1484,8 +1558,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0065",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0066",
@@ -1498,6 +1571,9 @@
         "Name": "isOn",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0066"
     ]
   },
   {
@@ -1505,7 +1581,9 @@
     "ReturnType": "void",
     "Name": "CALL_CLEAR_SAVE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0067"
     ]
   },
   {
@@ -1513,15 +1591,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0068",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0069",
     "ReturnType": "void",
     "Name": "CALL_FOOD_COURT",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0069"
     ]
   },
   {
@@ -1529,7 +1608,9 @@
     "ReturnType": "void",
     "Name": "CALL_STAFF_ROLL",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_006A"
     ]
   },
   {
@@ -1550,8 +1631,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_006C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x006d",
@@ -1576,8 +1656,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_006E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x006f",
@@ -1590,6 +1669,9 @@
         "Name": "bgmId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_006F"
     ]
   },
   {
@@ -1603,6 +1685,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0070"
     ]
   },
   {
@@ -1616,6 +1701,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0071"
     ]
   },
   {
@@ -1629,6 +1717,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0072"
     ]
   },
   {
@@ -1642,6 +1733,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0073"
     ]
   },
   {
@@ -1655,6 +1749,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0074"
     ]
   },
   {
@@ -1693,15 +1790,13 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0077",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0078",
     "ReturnType": "void",
     "Name": "FUNCTION_0078",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Event/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Event/Functions.json
@@ -15,6 +15,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0000"
     ]
   },
   {
@@ -41,6 +44,9 @@
         "Name": "cmmId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0002"
     ]
   },
   {
@@ -54,6 +60,9 @@
         "Name": "cmmId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0003"
     ]
   },
   {
@@ -118,8 +127,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0008",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3009",
@@ -144,16 +152,14 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300b",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300c",
@@ -178,8 +184,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300e",
@@ -192,6 +197,9 @@
         "Name": "cmmId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_000E"
     ]
   },
   {
@@ -236,6 +244,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0011"
     ]
   },
   {
@@ -254,6 +265,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0012"
     ]
   },
   {
@@ -318,16 +332,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3018",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0018",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3019",
@@ -347,16 +359,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x301b",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x301c",
@@ -407,8 +417,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3020",
@@ -454,8 +463,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3024",
@@ -488,16 +496,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3027",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3028",
@@ -577,6 +583,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_002C"
     ]
   },
   {
@@ -672,6 +681,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0031"
     ]
   },
   {
@@ -679,56 +691,49 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3033",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3034",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3035",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0035",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3036",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0036",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3037",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0037",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3038",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0038",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3039",
@@ -741,6 +746,9 @@
         "Name": "questId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0039"
     ]
   },
   {
@@ -754,6 +762,9 @@
         "Name": "questId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_003A"
     ]
   },
   {
@@ -779,7 +790,6 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_003C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Field/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4/Modules/Field/Functions.json
@@ -4,8 +4,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1001",
@@ -25,16 +24,14 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1003",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0003",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1004",
@@ -54,8 +51,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1006",
@@ -204,6 +200,9 @@
         "Name": "minor",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_000D"
     ]
   },
   {
@@ -314,16 +313,14 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0014",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1015",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0015",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1016",
@@ -341,6 +338,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0016"
     ]
   },
   {
@@ -359,6 +359,9 @@
         "Name": "speed",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0017"
     ]
   },
   {
@@ -377,6 +380,9 @@
         "Name": "speed",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0018"
     ]
   },
   {
@@ -384,56 +390,49 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0019",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101a",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101b",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101c",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101d",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101e",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101f",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1020",
@@ -476,55 +475,51 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0022",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1023",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1024",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0024",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1025",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0025",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1026",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1027",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1028",
     "ReturnType": "void",
     "Name": "FLD_EFFECT_TRAESTO_START",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0028"
     ]
   },
   {
@@ -581,8 +576,7 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_002C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102d",
@@ -674,7 +668,6 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/AI/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/AI/Functions.json
@@ -10,6 +10,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0000"
     ]
   },
   {
@@ -23,6 +26,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0001"
     ]
   },
   {
@@ -36,6 +42,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0002"
     ]
   },
   {
@@ -49,6 +58,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0003"
     ]
   },
   {
@@ -62,6 +74,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0004"
     ]
   },
   {
@@ -114,6 +129,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0008"
     ]
   },
   {
@@ -127,6 +145,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0009"
     ]
   },
   {
@@ -140,6 +161,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000A"
     ]
   },
   {
@@ -153,6 +177,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000B"
     ]
   },
   {
@@ -166,6 +193,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000C"
     ]
   },
   {
@@ -179,6 +209,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000D"
     ]
   },
   {
@@ -192,6 +225,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000E"
     ]
   },
   {
@@ -205,6 +241,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_000F"
     ]
   },
   {
@@ -218,6 +257,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0010"
     ]
   },
   {
@@ -231,6 +273,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0011"
     ]
   },
   {
@@ -238,23 +283,23 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2013",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2014",
     "ReturnType": "int",
     "Name": "AI_CHK_MY_FIRSTTURN",
     "Description": "This is checking if the user's turn is the first or not. NOTE: This function is only effective if the user has two turns in a row. The function will check out of those two turns if the first turn is current or not. The prime example usage of this function is Shadow Mitsuo",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0014"
     ]
   },
   {
@@ -307,6 +352,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0018"
     ]
   },
   {
@@ -320,6 +368,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0019"
     ]
   },
   {
@@ -333,6 +384,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001A"
     ]
   },
   {
@@ -346,6 +400,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001B"
     ]
   },
   {
@@ -359,6 +416,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001C"
     ]
   },
   {
@@ -372,6 +432,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001D"
     ]
   },
   {
@@ -385,6 +448,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001E"
     ]
   },
   {
@@ -398,6 +464,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_001F"
     ]
   },
   {
@@ -411,6 +480,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0020"
     ]
   },
   {
@@ -424,6 +496,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0021"
     ]
   },
   {
@@ -437,6 +512,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0022"
     ]
   },
   {
@@ -450,6 +528,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0023"
     ]
   },
   {
@@ -463,6 +544,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0024"
     ]
   },
   {
@@ -476,6 +560,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0025"
     ]
   },
   {
@@ -489,6 +576,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0026"
     ]
   },
   {
@@ -496,24 +586,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2028",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0028",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2029",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0029",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x202a",
@@ -526,6 +613,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_002A"
     ]
   },
   {
@@ -539,6 +629,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_002B"
     ]
   },
   {
@@ -546,7 +639,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_RND",
     "Description": "Target randomly",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_002C"
     ]
   },
   {
@@ -554,7 +649,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_LOWHP",
     "Description": "Target the lowest HP user",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_002D"
     ]
   },
   {
@@ -562,16 +659,14 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_002E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x202f",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_002F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2030",
@@ -584,6 +679,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0030"
     ]
   },
   {
@@ -597,6 +695,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0031"
     ]
   },
   {
@@ -610,6 +711,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0032"
     ]
   },
   {
@@ -617,7 +721,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_SELF",
     "Description": "Target itself",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0033"
     ]
   },
   {
@@ -625,7 +731,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_OTHERTHANSELF",
     "Description": "Target other than itself",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0034"
     ]
   },
   {
@@ -639,6 +747,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0035"
     ]
   },
   {
@@ -652,6 +763,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0036"
     ]
   },
   {
@@ -665,6 +779,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0037"
     ]
   },
   {
@@ -678,6 +795,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0038"
     ]
   },
   {
@@ -737,7 +857,9 @@
     "ReturnType": "void",
     "Name": "AI_ATTACK",
     "Description": "Command the enemy to do basic attack only",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_003D"
     ]
   },
   {
@@ -751,6 +873,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_003E"
     ]
   },
   {
@@ -758,7 +883,9 @@
     "ReturnType": "void",
     "Name": "AI_RUN_AWAY",
     "Description": "Command the enemy to run away",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_003F"
     ]
   },
   {
@@ -766,7 +893,9 @@
     "ReturnType": "void",
     "Name": "AI_WAIT",
     "Description": "Command the enemy to waste turn by waiting doing nothing",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0040"
     ]
   },
   {
@@ -780,6 +909,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0041"
     ]
   },
   {
@@ -787,23 +919,23 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0042",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2043",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0043",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2044",
     "ReturnType": "void",
     "Name": "AI_TAR_DOWN",
     "Description": "Target party member that have Down ailment condition",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0044"
     ]
   },
   {
@@ -811,7 +943,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_AILMENT",
     "Description": "Target party member that have ailment",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0045"
     ]
   },
   {
@@ -819,15 +953,16 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0046",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2047",
     "ReturnType": "int",
     "Name": "AI_IS_ENEMY_DOWN",
     "Description": "This is checking if the party members are DOWN",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0047"
     ]
   },
   {
@@ -835,7 +970,9 @@
     "ReturnType": "void",
     "Name": "AI_SKIP_MY_TURN",
     "Description": "Commands the enemy to skip their turn, doing nothing",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0048"
     ]
   },
   {
@@ -888,6 +1025,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_004C"
     ]
   },
   {
@@ -1044,6 +1184,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0058"
     ]
   },
   {
@@ -1062,6 +1205,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0059"
     ]
   },
   {
@@ -1080,6 +1226,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_005A"
     ]
   },
   {
@@ -1134,6 +1283,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_005D"
     ]
   },
   {
@@ -1152,6 +1304,9 @@
         "Name": "param2",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_005E"
     ]
   },
   {
@@ -1206,6 +1361,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0061"
     ]
   },
   {
@@ -1224,6 +1382,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0062"
     ]
   },
   {
@@ -1293,8 +1454,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0067",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2068",
@@ -1325,6 +1485,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0069"
     ]
   },
   {
@@ -1377,6 +1540,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_006D"
     ]
   },
   {
@@ -1390,6 +1556,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_006E"
     ]
   },
   {
@@ -1403,6 +1572,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_006F"
     ]
   },
   {
@@ -1442,6 +1614,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0072"
     ]
   },
   {
@@ -1591,8 +1766,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_007C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x207d",
@@ -1785,8 +1959,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0089",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208a",
@@ -1806,16 +1979,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_008B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208c",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_008C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x208d",
@@ -1861,8 +2032,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0090",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2091",
@@ -1875,6 +2045,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0091"
     ]
   },
   {
@@ -1882,24 +2055,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0092",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2093",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0093",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2094",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0094",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2095",
@@ -1938,6 +2108,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0097"
     ]
   },
   {
@@ -1951,6 +2124,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0098"
     ]
   },
   {
@@ -1958,24 +2134,21 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0099",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209a",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_009A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209b",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_009B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x209c",
@@ -2034,6 +2207,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_009E"
     ]
   },
   {
@@ -2088,6 +2264,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00A1"
     ]
   },
   {
@@ -2279,6 +2458,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00AD"
     ]
   },
   {
@@ -2297,6 +2479,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00AE"
     ]
   },
   {
@@ -2408,16 +2593,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00B7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20b8",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00B8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20b9",
@@ -2465,16 +2648,14 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00BB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20bc",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00BC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20bd",
@@ -2639,6 +2820,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00C1"
     ]
   },
   {
@@ -2646,32 +2830,28 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c3",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c4",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c5",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00C5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20c6",
@@ -2684,6 +2864,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00C6"
     ]
   },
   {
@@ -2697,6 +2880,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00C7"
     ]
   },
   {
@@ -2777,6 +2963,9 @@
         "Name": "param1",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00CC"
     ]
   },
   {
@@ -2797,16 +2986,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00CE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20cf",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00CF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20d0",
@@ -2889,6 +3076,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00D5"
     ]
   },
   {
@@ -2925,6 +3115,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00D7"
     ]
   },
   {
@@ -2950,7 +3143,9 @@
     "ReturnType": "int",
     "Name": "AI_CHK_IS_MYTURN_FIRSTACT",
     "Description": "Only use this for enemy that has 2 turns act in a row",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_00D9"
     ]
   },
   {
@@ -3002,48 +3197,42 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20de",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20df",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00DF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e0",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e1",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e2",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e3",
@@ -3081,8 +3270,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e6",
@@ -3115,8 +3303,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_00E8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20e9",
@@ -3181,6 +3368,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00ED"
     ]
   },
   {
@@ -3329,6 +3519,9 @@
         "Name": "tactic",
         "Description": "0 through 4. 0 being Act Freely, 4 being Direct Commands"
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00F8"
     ]
   },
   {
@@ -3342,6 +3535,9 @@
         "Name": "id",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00F9"
     ]
   },
   {
@@ -3375,8 +3571,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00FC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x20fd",
@@ -3442,6 +3637,9 @@
         "Name": "param5",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_00FE"
     ]
   },
   {
@@ -3449,8 +3647,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_00FF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2100",
@@ -3483,16 +3680,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0102",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2103",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0103",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2104",
@@ -3520,6 +3715,9 @@
         "Name": "param4",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0104"
     ]
   },
   {
@@ -3538,6 +3736,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0105"
     ]
   },
   {
@@ -3545,8 +3746,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0106",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2107",
@@ -3566,7 +3766,9 @@
     "ReturnType": "int",
     "Name": "AI_CHK_MITSUO_HAS_BLOCK",
     "Description": "This function is specific for Mitsuo. This checks if Mitsuo has a block or not",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0108"
     ]
   },
   {
@@ -3592,8 +3794,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_010A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x210b",
@@ -3629,6 +3830,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_010C"
     ]
   },
   {
@@ -3665,6 +3869,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_010E"
     ]
   },
   {
@@ -3683,6 +3890,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_010F"
     ]
   },
   {
@@ -3701,6 +3911,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0110"
     ]
   },
   {
@@ -3719,6 +3932,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0111"
     ]
   },
   {
@@ -3726,7 +3942,9 @@
     "ReturnType": "void",
     "Name": "AI_TAR_HIGHESTHP",
     "Description": "Target the user who has the highest HP value",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "AI_FUNCTION_0112"
     ]
   },
   {
@@ -3734,8 +3952,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0113",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2114",
@@ -3766,6 +3983,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0115"
     ]
   },
   {
@@ -3804,8 +4024,7 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_0118",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2119",
@@ -3825,16 +4044,14 @@
     "ReturnType": "int",
     "Name": "AI_FUNCTION_011A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x211b",
     "ReturnType": "int",
     "Name": "AI_FUNCTION_011B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x211c",
@@ -3854,8 +4071,7 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_011D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x211e",
@@ -3952,6 +4168,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "AI_FUNCTION_0121"
     ]
   },
   {
@@ -3959,16 +4178,14 @@
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0122",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2123",
     "ReturnType": "void",
     "Name": "AI_FUNCTION_0123",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2124",

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Common/Functions.json
@@ -11,6 +11,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0000"
     ]
   },
   {
@@ -18,7 +21,9 @@
     "ReturnType": "void",
     "Name": "OPEN_MSG_WIN",
     "Description": "Code function name: itfMesManager__sub_8101F8DC",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0001"
     ]
   },
   {
@@ -26,7 +31,9 @@
     "ReturnType": "void",
     "Name": "CLOSE_MSG_WIN",
     "Description": "Code function name: itfMesManager__sub_8101F93C",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -41,6 +48,9 @@
         "Description": "",
         "Semantic": "SelId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -48,16 +58,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0004",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0005",
     "ReturnType": "void",
     "Name": "FUNCTION_0005",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0006",
@@ -80,6 +88,9 @@
         "Name": "unknown2",
         "Description": "Enum for which type of variable? 0 for int using [f 2 4 index] and 1 for item string using [f 2 5 3 -1 index]"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0006"
     ]
   },
   {
@@ -98,6 +109,9 @@
         "Name": "choice",
         "Description": "Index of sel to choose"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0007"
     ]
   },
   {
@@ -111,6 +125,9 @@
         "Name": "mask",
         "Description": "Bit mask to hide choices"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0008"
     ]
   },
   {
@@ -125,6 +142,9 @@
         "Description": "",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0009"
     ]
   },
   {
@@ -139,6 +159,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000A"
     ]
   },
   {
@@ -153,6 +176,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000B"
     ]
   },
   {
@@ -167,6 +193,9 @@
         "Description": "",
         "Semantic": "BitId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000C"
     ]
   },
   {
@@ -180,6 +209,9 @@
         "Name": "param1",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000D"
     ]
   },
   {
@@ -193,6 +225,9 @@
         "Name": "x",
         "Description": "The number to get the square root of"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_000E"
     ]
   },
   {
@@ -200,8 +235,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_000F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0010",
@@ -214,6 +248,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0010"
     ]
   },
   {
@@ -253,6 +290,9 @@
         "Name": "param1",
         "Description": "The input isn't even read although it says it takes one"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0013"
     ]
   },
   {
@@ -266,6 +306,9 @@
         "Name": "param1",
         "Description": "The input isn't even read although it says it takes one"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0014"
     ]
   },
   {
@@ -279,6 +322,9 @@
         "Name": "fadeLength",
         "Description": "How long it will take to fade back (30 is 1 second)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0015"
     ]
   },
   {
@@ -297,6 +343,9 @@
         "Name": "fadeLength",
         "Description": "How long it will take to fade to black (30 is 1 second)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0016"
     ]
   },
   {
@@ -304,7 +353,9 @@
     "ReturnType": "void",
     "Name": "FADE_SYNC",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0017"
     ]
   },
   {
@@ -371,6 +422,9 @@
         "Name": "param2",
         "Description": "Probably the index of the bf file to call the procedure from, hard to say how this actually works though 0 appears to be the current bf file"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0019"
     ]
   },
   {
@@ -441,6 +495,9 @@
         "Name": "intensity",
         "Description": "How intense the screen shake is (0 is no shake, going too high may cause the camera to clip through the roof)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_001E"
     ]
   },
   {
@@ -448,8 +505,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0020",
@@ -477,6 +533,9 @@
         "Name": "param4",
         "Description": "Unknown type; assumed int"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0020"
     ]
   },
   {
@@ -490,6 +549,9 @@
         "Name": "INDEX",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0021"
     ]
   },
   {
@@ -508,6 +570,9 @@
         "Name": "AMOUNT",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0022"
     ]
   },
   {
@@ -526,6 +591,9 @@
         "Name": "minor",
         "Description": "The minor id of the sound effect."
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0023"
     ]
   },
   {
@@ -549,6 +617,9 @@
         "Name": "b",
         "Description": "The blue component of the colour"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0024"
     ]
   },
   {
@@ -574,6 +645,9 @@
         "Name": "param3",
         "Description": "Bit mask to disable options"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0025"
     ]
   },
   {
@@ -607,6 +681,9 @@
         "Name": "param5",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0026"
     ]
   },
   {
@@ -640,6 +717,9 @@
         "Name": "param5",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0027"
     ]
   },
   {
@@ -667,6 +747,9 @@
         "Description": "The message to display in the black text box below the forecast",
         "Semantic": "MsgId"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0029"
     ]
   },
   {
@@ -686,6 +769,9 @@
         "Name": "titleId",
         "Description": "The id of the message to display as the title. This is pulled from a bmd somewhere (not sure which one)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_002A"
     ]
   },
   {
@@ -693,40 +779,35 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002c",
     "ReturnType": "void",
     "Name": "FUNCTION_002C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002d",
     "ReturnType": "void",
     "Name": "FUNCTION_002D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002e",
     "ReturnType": "void",
     "Name": "FUNCTION_002E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002f",
     "ReturnType": "void",
     "Name": "FUNCTION_002F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0030",
@@ -754,6 +835,9 @@
         "Name": "weather",
         "Description": "If 0 uses the current weather otherwise it will change the weather in the field called (doesn't actually change the weather just the visuals)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0030"
     ]
   },
   {
@@ -782,6 +866,9 @@
         "Name": "weather",
         "Description": "If 0 uses the current weather otherwise it will change the weather in the field called (doesn't actually change the weather just the visuals)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0031"
     ]
   },
   {
@@ -805,6 +892,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0032"
     ]
   },
   {
@@ -812,7 +902,9 @@
     "ReturnType": "int",
     "Name": "GET_MONTH",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0033"
     ]
   },
   {
@@ -820,7 +912,9 @@
     "ReturnType": "int",
     "Name": "GET_DAY_OF_MONTH",
     "Description": "Returns day of the month",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0034"
     ]
   },
   {
@@ -828,7 +922,9 @@
     "ReturnType": "int",
     "Name": "GET_DAY_OF_WEEK",
     "Description": "Returns day of the week as int from 0 to 6.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0035"
     ]
   },
   {
@@ -836,7 +932,9 @@
     "ReturnType": "int",
     "Name": "GET_TIME_OF_DAY",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0036"
     ]
   },
   {
@@ -855,6 +953,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0037"
     ]
   },
   {
@@ -868,6 +969,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0038"
     ]
   },
   {
@@ -881,6 +985,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0039"
     ]
   },
   {
@@ -888,8 +995,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x003b",
@@ -902,6 +1008,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003B"
     ]
   },
   {
@@ -909,7 +1018,9 @@
     "ReturnType": "void",
     "Name": "TV_STUDIO",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_003C"
     ]
   },
   {
@@ -933,6 +1044,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003D"
     ]
   },
   {
@@ -946,6 +1060,9 @@
         "Name": "floorID",
         "Description": "ID of the floor to load"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003E"
     ]
   },
   {
@@ -964,6 +1081,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_003F"
     ]
   },
   {
@@ -992,6 +1112,9 @@
         "Name": "date2Day",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0040"
     ]
   },
   {
@@ -1010,6 +1133,9 @@
         "Name": "expression",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0041"
     ]
   },
   {
@@ -1028,6 +1154,9 @@
         "Name": "increaseAmount",
         "Description": "The amount to increase the social stat by"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0042"
     ]
   },
   {
@@ -1059,6 +1188,9 @@
         "Name": "statId",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0044"
     ]
   },
   {
@@ -1082,6 +1214,9 @@
         "Name": "increaseAmount",
         "Description": "The amount to increase the stat by"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0045"
     ]
   },
   {
@@ -1105,6 +1240,9 @@
         "Name": "increaseAmount",
         "Description": "The amount to increase the stat by"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0046"
     ]
   },
   {
@@ -1123,6 +1261,9 @@
         "Name": "stat",
         "Description": "The stat to check"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0047"
     ]
   },
   {
@@ -1130,7 +1271,9 @@
     "ReturnType": "int",
     "Name": "GET_CURRENT_PERSONA",
     "Description": "Returns the id of the currently equipped Persona",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0048"
     ]
   },
   {
@@ -1138,7 +1281,9 @@
     "ReturnType": "void",
     "Name": "DAIDARA_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0049"
     ]
   },
   {
@@ -1146,7 +1291,9 @@
     "ReturnType": "void",
     "Name": "SHIROKU_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004A"
     ]
   },
   {
@@ -1154,7 +1301,9 @@
     "ReturnType": "void",
     "Name": "VELVET_ROOM",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004B"
     ]
   },
   {
@@ -1162,7 +1311,9 @@
     "ReturnType": "int",
     "Name": "GET_WEATHER",
     "Description": "Returns the weather,0=Clear,1= Rain, 2= Cloudy, Thunderstorm",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004C"
     ]
   },
   {
@@ -1170,23 +1321,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_004D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004e",
     "ReturnType": "int",
     "Name": "FUNCTION_004E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x004f",
     "ReturnType": "void",
     "Name": "SOFT_RESET",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_004F"
     ]
   },
   {
@@ -1200,6 +1351,9 @@
         "Name": "Yen_Amount",
         "Description": "How much you want to change the money value by"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0050"
     ]
   },
   {
@@ -1207,7 +1361,9 @@
     "ReturnType": "void",
     "Name": "SET_NAME",
     "Description": "Takes the player to the menu where they choose their name",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0051"
     ]
   },
   {
@@ -1221,6 +1377,9 @@
         "Name": "index",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0052"
     ]
   },
   {
@@ -1239,6 +1398,9 @@
         "Name": "count",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0053"
     ]
   },
   {
@@ -1257,6 +1419,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0054"
     ]
   },
   {
@@ -1280,6 +1445,9 @@
         "Name": "equipmentId",
         "Description": "The id of the equipment to equip"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0055"
     ]
   },
   {
@@ -1287,15 +1455,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0056",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0057",
     "ReturnType": "int",
     "Name": "NS_SAVE",
     "Description": "Pulls up the save menu and saves.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0057"
     ]
   },
   {
@@ -1303,7 +1472,9 @@
     "ReturnType": "int",
     "Name": "LOAD",
     "Description": "Opens the load menu. Returns 1 if the player selected a save, 0 if they cancelled. This doesn't actually load the game it just makes the screen black another function must be needed",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0058"
     ]
   },
   {
@@ -1311,7 +1482,9 @@
     "ReturnType": "void",
     "Name": "NOTHING6",
     "Description": "Does nothing, the function immediately returns",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0059"
     ]
   },
   {
@@ -1325,6 +1498,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005A"
     ]
   },
   {
@@ -1338,6 +1514,9 @@
         "Name": "partyMember",
         "Description": "The party member whose Persona should be reborn"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005B"
     ]
   },
   {
@@ -1366,6 +1545,9 @@
         "Name": "minor",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005C"
     ]
   },
   {
@@ -1379,6 +1561,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005D"
     ]
   },
   {
@@ -1392,6 +1577,9 @@
         "Name": "partyMember",
         "Description": "The party member whose hp should be returned"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005E"
     ]
   },
   {
@@ -1405,6 +1593,9 @@
         "Name": "partyMember",
         "Description": "The party member whose hp should be returned"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_005F"
     ]
   },
   {
@@ -1423,6 +1614,9 @@
         "Name": "newHp",
         "Description": "The value to set the party member's hp to"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0060"
     ]
   },
   {
@@ -1436,6 +1630,9 @@
         "Name": "partyMember",
         "Description": "The party member whose sp should be returned"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0061"
     ]
   },
   {
@@ -1449,6 +1646,9 @@
         "Name": "partyMember",
         "Description": "The party member whose sp should be returned"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0062"
     ]
   },
   {
@@ -1467,6 +1667,9 @@
         "Name": "newHp",
         "Description": "The value to set the party member's sp to"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0063"
     ]
   },
   {
@@ -1480,6 +1683,9 @@
         "Name": "cutsceneId",
         "Description": "The id of the cutscene to play"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0064"
     ]
   },
   {
@@ -1487,8 +1693,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0065",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0066",
@@ -1501,6 +1706,9 @@
         "Name": "dateShown",
         "Description": "If 0 the date is hidden, 1 it's shown"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0066"
     ]
   },
   {
@@ -1508,7 +1716,9 @@
     "ReturnType": "void",
     "Name": "NG_PLUS_SAVE",
     "Description": "Code function name: mc_clear___sub_8129DBB8",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0067"
     ]
   },
   {
@@ -1516,15 +1726,16 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0068",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0069",
     "ReturnType": "void",
     "Name": "JUNES_FOODCOURT",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0069"
     ]
   },
   {
@@ -1532,7 +1743,9 @@
     "ReturnType": "void",
     "Name": "BAD_END_CREDITS",
     "Description": "Code function name: ed_sr_sub_81299624",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_006A"
     ]
   },
   {
@@ -1553,7 +1766,9 @@
     "ReturnType": "void",
     "Name": "NOTHING7",
     "Description": "Does nothing, the function immediately returns",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_006C"
     ]
   },
   {
@@ -1572,6 +1787,9 @@
         "Name": "minor",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_006D"
     ]
   },
   {
@@ -1579,7 +1797,9 @@
     "ReturnType": "void",
     "Name": "NOTHING8",
     "Description": "Does nothing, the function immediately returns",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_006E"
     ]
   },
   {
@@ -1593,6 +1813,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_006F"
     ]
   },
   {
@@ -1606,6 +1829,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0070"
     ]
   },
   {
@@ -1619,6 +1845,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0071"
     ]
   },
   {
@@ -1632,6 +1861,9 @@
         "Name": "duration",
         "Description": "How long it takes to fade to nothing"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0072"
     ]
   },
   {
@@ -1645,6 +1877,9 @@
         "Name": "id",
         "Description": "The id of the sound effect to play"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0073"
     ]
   },
   {
@@ -1689,6 +1924,9 @@
         "Name": "expression",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0076"
     ]
   },
   {
@@ -1696,16 +1934,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0077",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0078",
     "ReturnType": "void",
     "Name": "FUNCTION_0078",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0079",
@@ -1743,8 +1979,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_007B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x007c",
@@ -1764,7 +1999,9 @@
     "ReturnType": "void",
     "Name": "OPEN_CALENDAR",
     "Description": "Code function name: cmpCalendar_sub_8114FEBC",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_007D"
     ]
   },
   {
@@ -1772,7 +2009,9 @@
     "ReturnType": "void",
     "Name": "SHIROKU_PUB",
     "Description": "Goes to Shiroku Pub",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_007E"
     ]
   },
   {
@@ -1780,7 +2019,9 @@
     "ReturnType": "void",
     "Name": "CROCOFUR_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_007F"
     ]
   },
   {
@@ -1794,6 +2035,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0080"
     ]
   },
   {
@@ -1801,7 +2045,9 @@
     "ReturnType": "void",
     "Name": "PRODUCE_SHOP",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0081"
     ]
   },
   {
@@ -1809,7 +2055,9 @@
     "ReturnType": "void",
     "Name": "BOOK_READ",
     "Description": "Code function name: cmpBook_sub_8114E452",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0082"
     ]
   },
   {
@@ -1846,6 +2094,9 @@
         "Name": "param2",
         "Description": "requires more investigation"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0084"
     ]
   },
   {
@@ -1853,48 +2104,42 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0085",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0086",
     "ReturnType": "void",
     "Name": "FUNCTION_0086",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0087",
     "ReturnType": "void",
     "Name": "FUNCTION_0087",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0088",
     "ReturnType": "int",
     "Name": "FUNCTION_0088",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0089",
     "ReturnType": "int",
     "Name": "FUNCTION_0089",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008a",
     "ReturnType": "int",
     "Name": "FUNCTION_008A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x008b",
@@ -1932,7 +2177,9 @@
     "ReturnType": "void",
     "Name": "CALL_MARIE_DNG_TV",
     "Description": "Calls for the team to meet infront of the tv to maries dungeon.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_008D"
     ]
   },
   {
@@ -1959,6 +2206,9 @@
         "Name": "bait",
         "Description": "Some kind of indicator of what bait was used which probably affects the chance of getting specific bugs. Bait is an unused feature, in game 0 is always used."
       }
+    ],
+    "Aliases": [
+      "FUNCTION_008F"
     ]
   },
   {
@@ -1966,7 +2216,9 @@
     "ReturnType": "void",
     "Name": "SAVE_STORY",
     "Description": "Gives you a warning about story changes and then asks you to save.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0090"
     ]
   },
   {
@@ -1974,8 +2226,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0091",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0092",
@@ -1988,6 +2239,9 @@
         "Name": "Location ID",
         "Description": "The ID of the location that the save is made in"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0092"
     ]
   },
   {
@@ -1995,7 +2249,9 @@
     "ReturnType": "void",
     "Name": "NS_DISABLE_PLAYER_MOVEMENT",
     "Description": "Stops player from moving. To be used with SAVE_ASK",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_0093"
     ]
   },
   {
@@ -2009,6 +2265,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0094"
     ]
   },
   {
@@ -2047,16 +2306,14 @@
     "ReturnType": "int",
     "Name": "FUNCTION_0097",
     "Description": "Code function name: modeCustom____sub_8124483C",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0098",
     "ReturnType": "int",
     "Name": "FUNCTION_0098",
     "Description": "Code function name: modeCustom____sub_81244926",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0099",
@@ -2081,24 +2338,21 @@
     "ReturnType": "void",
     "Name": "FUNCTION_009A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x009b",
     "ReturnType": "void",
     "Name": "FUNCTION_009B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x009c",
     "ReturnType": "void",
     "Name": "FUNCTION_009C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x009d",
@@ -2164,6 +2418,9 @@
         "Name": "param2",
         "Description": "If 0 checks for moves to remember, if 1 checks for new moves"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_009E"
     ]
   },
   {
@@ -2177,6 +2434,9 @@
         "Name": "param1",
         "Description": "Only 1 and 0 seem to work (the game only uses 1 where this is called)"
       }
+    ],
+    "Aliases": [
+      "FUNCTION_009F"
     ]
   },
   {
@@ -2184,24 +2444,21 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00A0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a1",
     "ReturnType": "void",
     "Name": "FUNCTION_00A1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a2",
     "ReturnType": "void",
     "Name": "FUNCTION_00A2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00a3",
@@ -2231,7 +2488,9 @@
     "ReturnType": "void",
     "Name": "TRANSITION_EPILOGUE",
     "Description": "Calender transition used in the epilogue",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00A4"
     ]
   },
   {
@@ -2306,32 +2565,28 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00A9",
     "Description": "Code function name: chQuiz_sub_8123B2B4",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00aa",
     "ReturnType": "int",
     "Name": "FUNCTION_00AA",
     "Description": "Code function name: chQuiz_sub_8123B3A6",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00ab",
     "ReturnType": "void",
     "Name": "FUNCTION_00AB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00ac",
     "ReturnType": "void",
     "Name": "FUNCTION_00AC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00ad",
@@ -2369,16 +2624,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00AF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b0",
     "ReturnType": "int",
     "Name": "FUNCTION_00B0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b1",
@@ -2398,40 +2651,35 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00B2",
     "Description": "Code function name: chQuiz_sub_8123B668",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b3",
     "ReturnType": "int",
     "Name": "FUNCTION_00B3",
     "Description": "Code function name: insectScript___sub_8129C7A8",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b4",
     "ReturnType": "void",
     "Name": "FUNCTION_00B4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b5",
     "ReturnType": "int",
     "Name": "FUNCTION_00B5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b6",
     "ReturnType": "void",
     "Name": "FUNCTION_00B6",
     "Description": "Code function name: chQuiz_sub_8123C0C2",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b7",
@@ -2451,8 +2699,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_00B8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00b9",
@@ -2485,23 +2732,23 @@
     "ReturnType": "void",
     "Name": "FUNCTION_00BB",
     "Description": "Code function name: chQuiz_sub_8123C194",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bc",
     "ReturnType": "void",
     "Name": "FUNCTION_00BC",
     "Description": "Code function name: cldScheduler_sub_810448F6",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x00bd",
     "ReturnType": "void",
     "Name": "HD_CALL_ALBUM",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00BD"
     ]
   },
   {
@@ -2509,7 +2756,9 @@
     "ReturnType": "void",
     "Name": "HD_FUNCTION_00BE",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FUNCTION_00BE"
     ]
   },
   {
@@ -2528,6 +2777,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_00BF"
     ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Event/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Event/Functions.json
@@ -15,6 +15,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0000"
     ]
   },
   {
@@ -54,6 +57,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0003"
     ]
   },
   {
@@ -67,6 +73,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0004"
     ]
   },
   {
@@ -118,8 +127,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0008",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3009",
@@ -144,16 +152,14 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_000A",
     "Description": "Code function name: cmmScript_sub_811E71E8",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300b",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300c",
@@ -178,8 +184,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300e",
@@ -192,6 +197,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_000E"
     ]
   },
   {
@@ -236,6 +244,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0011"
     ]
   },
   {
@@ -254,6 +265,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0012"
     ]
   },
   {
@@ -318,16 +332,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3018",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0018",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3019",
@@ -347,16 +359,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x301b",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x301c",
@@ -407,8 +417,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3020",
@@ -454,8 +463,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3024",
@@ -488,16 +496,14 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3027",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3028",
@@ -577,6 +583,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_002C"
     ]
   },
   {
@@ -679,56 +688,49 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3033",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3034",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0034",
     "Description": "Code function name: cmmScript_sub_811E7DD0",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3035",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0035",
     "Description": "Code function name: cmmScript_sub_811E7EA2",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3036",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0036",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3037",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0037",
     "Description": "Code function name: cmmScript_sub_811E7F46",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3038",
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_0038",
     "Description": "Code function name: cmmScript_sub_811E8000",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3039",
@@ -741,6 +743,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_0039"
     ]
   },
   {
@@ -754,6 +759,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_003A"
     ]
   },
   {
@@ -779,48 +787,42 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_003C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303d",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_003D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303e",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_003E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303f",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_003F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3040",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0040",
     "Description": "Code function name: evtScript____sub_8122607A",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3041",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0041",
     "Description": "Code function name: evtScript____sub_81226190",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3042",
@@ -899,8 +901,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0046",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3047",
@@ -969,8 +970,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_004B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x304c",
@@ -993,6 +993,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_004C"
     ]
   },
   {
@@ -1011,6 +1014,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "EVT_FUNCTION_004D"
     ]
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Facility/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Facility/Functions.json
@@ -4,55 +4,48 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4001",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0001",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4002",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4003",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0003",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4004",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4005",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4006",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0006",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Field/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Field/Functions.json
@@ -4,8 +4,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1001",
@@ -18,6 +17,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0001"
     ]
   },
   {
@@ -25,7 +27,9 @@
     "ReturnType": "int",
     "Name": "GET_FLOOR_ID",
     "Description": "Returns 0 if not in dungeon, ID of floor otherwise.",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0002"
     ]
   },
   {
@@ -33,7 +37,9 @@
     "ReturnType": "void",
     "Name": "RESET_FLOOR",
     "Description": "Makes new floor",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0003"
     ]
   },
   {
@@ -54,8 +60,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1006",
@@ -204,6 +209,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_000D"
     ]
   },
   {
@@ -314,16 +322,14 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0014",
     "Description": "Code function name: k_command____sub_810A880E",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1015",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0015",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1016",
@@ -341,6 +347,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_0016"
     ]
   },
   {
@@ -384,56 +393,49 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0019",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101a",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101b",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101c",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101d",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101e",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_001E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101f",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1020",
@@ -476,7 +478,9 @@
     "ReturnType": "int",
     "Name": "GET_FIELD_MAJOR",
     "Description": "Returns major id of current field",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0022"
     ]
   },
   {
@@ -484,7 +488,9 @@
     "ReturnType": "int",
     "Name": "GET_FIELD_MINOR",
     "Description": "Returns minor id of current field",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0023"
     ]
   },
   {
@@ -492,39 +498,37 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0024",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1025",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0025",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1026",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1027",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0027",
     "Description": "Code function name: k_command____sub_810A8834",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1028",
     "ReturnType": "void",
     "Name": "TRAESTO_VISUAL",
     "Description": "",
-    "Parameters": [
+    "Parameters": [],
+    "Aliases": [
+      "FLD_FUNCTION_0028"
     ]
   },
   {
@@ -556,6 +560,9 @@
         "Name": "param2",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FLD_FUNCTION_002A"
     ]
   },
   {
@@ -581,8 +588,7 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_002C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102d",
@@ -674,88 +680,77 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1033",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1034",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1035",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0035",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1036",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0036",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1037",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0037",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1038",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0038",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1039",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0039",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103a",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103b",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_003B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103c",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_003C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103d",
@@ -785,16 +780,14 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_003E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103f",
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_003F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1040",
@@ -832,8 +825,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0042",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1043",
@@ -884,8 +876,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0046",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1047",
@@ -920,16 +911,14 @@
     "ReturnType": "void",
     "Name": "FLD_FUNCTION_0048",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1049",
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_0049",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104a",
@@ -949,8 +938,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_004B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104c",
@@ -970,8 +958,7 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_004D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104e",
@@ -991,7 +978,6 @@
     "ReturnType": "int",
     "Name": "FLD_FUNCTION_004F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Net/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/Persona4Golden/Modules/Net/Functions.json
@@ -4,7 +4,6 @@
     "ReturnType": "void",
     "Name": "NET_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Battle/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Battle/Functions.json
@@ -56,8 +56,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3005",
@@ -95,56 +94,49 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0007",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3008",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0008",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3009",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0009",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300a",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300b",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300c",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_000C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300d",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x300e",
@@ -177,8 +169,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0010",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3011",
@@ -198,16 +189,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3013",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3014",
@@ -375,8 +364,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x301c",
@@ -447,88 +435,77 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_001F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3020",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0020",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3021",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0021",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3022",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0022",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3023",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3024",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0024",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3025",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0025",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3026",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3027",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3028",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0028",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3029",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0029",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x302a",
@@ -600,40 +577,35 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_002F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3030",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0030",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3031",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0031",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3032",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0032",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3033",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3034",
@@ -728,32 +700,28 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303b",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_003B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303c",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_003C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303d",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_003D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x303e",
@@ -934,8 +902,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_004B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x304c",
@@ -1040,8 +1007,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0052",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3053",
@@ -1268,8 +1234,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0062",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3063",
@@ -1330,8 +1295,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0066",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3067",
@@ -1351,16 +1315,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0068",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3069",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0069",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x306a",
@@ -1406,16 +1368,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_006D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x306e",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_006E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x306f",
@@ -1463,16 +1423,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0071",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3072",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0072",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3073",
@@ -1543,80 +1501,70 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0076",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3077",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0077",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3078",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0078",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3079",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0079",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307a",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_007A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307b",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_007B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307c",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_007C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307d",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_007D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307e",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_007E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x307f",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_007F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3080",
@@ -1636,8 +1584,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0081",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3082",
@@ -1720,32 +1667,28 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0084",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3085",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0085",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3086",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0086",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3087",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0087",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3088",
@@ -1891,104 +1834,91 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0090",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3091",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0091",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3092",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0092",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3093",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0093",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3094",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0094",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3095",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0095",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3096",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0096",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3097",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0097",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3098",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0098",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3099",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0099",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x309a",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_009A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x309b",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_009B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x309c",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_009C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x309d",
@@ -2031,8 +1961,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_009F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30a0",
@@ -2158,8 +2087,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00A3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30a4",
@@ -2214,8 +2142,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00A5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30a6",
@@ -2341,8 +2268,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00A9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30aa",
@@ -2443,16 +2369,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00AD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30ae",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00AE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30af",
@@ -2477,32 +2401,28 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00B0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b1",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00B1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b2",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00B2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b3",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00B3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b4",
@@ -2575,16 +2495,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00B6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b7",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00B7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30b8",
@@ -2723,8 +2641,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00BC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30bd",
@@ -2744,8 +2661,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00BE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30bf",
@@ -2848,8 +2764,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00C1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30c2",
@@ -2935,16 +2850,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00C5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30c6",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00C6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30c7",
@@ -2964,24 +2877,21 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00C8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30c9",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00C9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30ca",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00CA",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30cb",
@@ -3001,8 +2911,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00CC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30cd",
@@ -3110,8 +3019,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00D4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30d5",
@@ -3170,8 +3078,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00D9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30da",
@@ -3358,24 +3265,21 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00DF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30e0",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00E0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30e1",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00E1",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30e2",
@@ -3408,8 +3312,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00E4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30e5",
@@ -3545,8 +3448,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00ED",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30ee",
@@ -3584,8 +3486,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00F0",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30f1",
@@ -3605,16 +3506,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00F2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30f3",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00F3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30f4",
@@ -3670,24 +3569,21 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00F7",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30f8",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00F8",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30f9",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_00F9",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30fa",
@@ -3730,16 +3626,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00FC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30fd",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_00FD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x30fe",
@@ -3798,8 +3692,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0102",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3103",
@@ -4104,8 +3997,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_010E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x310f",
@@ -4145,16 +4037,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0110",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3111",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0111",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3112",
@@ -4284,8 +4174,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0118",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3119",
@@ -4387,8 +4276,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_011E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x311f",
@@ -4413,8 +4301,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0120",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3121",
@@ -4434,32 +4321,28 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0122",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3123",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0123",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3124",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0124",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3125",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0125",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3126",
@@ -4551,8 +4434,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_012B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x312c",
@@ -4608,8 +4490,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_012F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3130",
@@ -4773,16 +4654,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0139",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x313a",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_013A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x313b",
@@ -4848,8 +4727,7 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_013E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x313f",
@@ -4910,16 +4788,14 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0142",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3143",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0143",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3144",
@@ -4985,8 +4861,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0147",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3148",
@@ -5029,8 +4904,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_014A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x314b",
@@ -5073,8 +4947,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_014D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x314e",
@@ -5107,16 +4980,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0150",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3151",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0151",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3152",
@@ -5136,40 +5007,35 @@
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0153",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3154",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0154",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3155",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0155",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3156",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0156",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3157",
     "ReturnType": "int",
     "Name": "BTL_FUNCTION_0157",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3158",
@@ -5231,6 +5097,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "BTL_FUNCTION_015B"
     ]
   },
   {
@@ -5238,8 +5107,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_015C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x315d",
@@ -5264,48 +5132,42 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_015E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x315f",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_015F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3160",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0160",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3161",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0161",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3162",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0162",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3163",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0163",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3164",
@@ -5393,72 +5255,63 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0166",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3167",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0167",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3168",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0168",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3169",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0169",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316a",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_016A",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316b",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_016B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316c",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_016C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316d",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_016D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316e",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_016E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x316f",
@@ -6161,8 +6014,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_018F",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3190",
@@ -6218,16 +6070,14 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0193",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3194",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0194",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3195",
@@ -6288,8 +6138,7 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_0198",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x3199",
@@ -6332,32 +6181,28 @@
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_019B",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x319c",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_019C",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x319d",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_019D",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x319e",
     "ReturnType": "void",
     "Name": "BTL_FUNCTION_019E",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x319f",
@@ -6418,6 +6263,9 @@
         "Name": "param3",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "BTL_FUNCTION_01A0"
     ]
   },
   {

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Camp/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Camp/Functions.json
@@ -197,16 +197,14 @@
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x800c",
     "ReturnType": "void",
     "Name": "CAMP_FUNCTION_000C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x800d",
@@ -226,8 +224,7 @@
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_000E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x800f",
@@ -273,32 +270,28 @@
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x8013",
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x8014",
     "ReturnType": "void",
     "Name": "CAMP_FUNCTION_0014",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x8015",
     "ReturnType": "void",
     "Name": "CAMP_FUNCTION_0015",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x8016",
@@ -357,15 +350,13 @@
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x801b",
     "ReturnType": "int",
     "Name": "CAMP_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Common/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Common/Functions.json
@@ -4,8 +4,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0001",
@@ -31,6 +30,9 @@
         "Name": "value",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0002"
     ]
   },
   {
@@ -44,6 +46,9 @@
         "Name": "str",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0003"
     ]
   },
   {
@@ -100,8 +105,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0007",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0008",
@@ -214,8 +218,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_000F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0010",
@@ -271,8 +274,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0014",
@@ -399,8 +401,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0019",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x001a",
@@ -446,8 +447,7 @@
     "ReturnType": "int",
     "Name": "FUNCTION_001D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x001e",
@@ -485,16 +485,14 @@
     "ReturnType": "void",
     "Name": "FUNCTION_0020",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0021",
     "ReturnType": "int",
     "Name": "FUNCTION_0021",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x0022",
@@ -574,6 +572,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0026"
     ]
   },
   {
@@ -587,6 +588,9 @@
         "Name": "param1",
         "Description": ""
       }
+    ],
+    "Aliases": [
+      "FUNCTION_0027"
     ]
   },
   {
@@ -638,8 +642,7 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x002c",
@@ -685,7 +688,6 @@
     "ReturnType": "void",
     "Name": "FUNCTION_002F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Dungeon/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Dungeon/Functions.json
@@ -4,16 +4,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1001",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0001",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1002",
@@ -77,8 +75,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0006",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1007",
@@ -154,16 +151,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x100b",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x100c",
@@ -188,96 +183,84 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x100e",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_000E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x100f",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_000F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1010",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0010",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1011",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0011",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1012",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1013",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1014",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0014",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1015",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0015",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1016",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0016",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1017",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1018",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0018",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1019",
@@ -338,16 +321,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_001C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101d",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_001D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x101e",
@@ -429,8 +410,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1024",
@@ -503,16 +483,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0026",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1027",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0027",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1028",
@@ -545,24 +523,21 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_002A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102b",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_002B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102c",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_002C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102d",
@@ -592,8 +567,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_002E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x102f",
@@ -628,8 +602,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0030",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1031",
@@ -672,16 +645,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1034",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1035",
@@ -714,32 +685,28 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0037",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1038",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0038",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1039",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0039",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103a",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103b",
@@ -772,24 +739,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_003D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103e",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_003E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x103f",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_003F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1040",
@@ -923,40 +887,35 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0044",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1045",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0045",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1046",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0046",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1047",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0047",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1048",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0048",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1049",
@@ -1001,16 +960,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_004A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104b",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_004B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104c",
@@ -1035,8 +992,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_004D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x104e",
@@ -1071,24 +1027,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_004F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1050",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0050",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1051",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0051",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1052",
@@ -1164,8 +1117,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0055",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1056",
@@ -1236,8 +1188,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0059",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x105a",
@@ -1362,8 +1313,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0060",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1061",
@@ -1388,24 +1338,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0062",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1063",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0063",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1064",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0064",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1065",
@@ -1425,40 +1372,35 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0066",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1067",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0067",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1068",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0068",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1069",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0069",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x106a",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_006A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x106b",
@@ -1483,16 +1425,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_006C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x106d",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_006D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x106e",
@@ -1551,8 +1491,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0072",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1073",
@@ -1680,24 +1619,21 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_007A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x107b",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_007B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x107c",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_007C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x107d",
@@ -1727,32 +1663,28 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_007E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x107f",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_007F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1080",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0080",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1081",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0081",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1082",
@@ -1828,16 +1760,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0085",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1086",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0086",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1087",
@@ -1890,8 +1820,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0089",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x108a",
@@ -1924,8 +1853,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_008C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x108d",
@@ -1963,8 +1891,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_008F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1090",
@@ -1994,8 +1921,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0091",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1092",
@@ -2025,40 +1951,35 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0093",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1094",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0094",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1095",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0095",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1096",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0096",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1097",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0097",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1098",
@@ -2428,24 +2349,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00AD",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ae",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00AE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10af",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00AF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10b0",
@@ -2557,40 +2475,35 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00B5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10b6",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00B6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10b7",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00B7",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10b8",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00B8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10b9",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00B9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ba",
@@ -2682,8 +2595,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00BF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10c0",
@@ -2729,8 +2641,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00C3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10c4",
@@ -2750,16 +2661,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00C5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10c6",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00C6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10c7",
@@ -2802,16 +2711,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00C9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ca",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00CA",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10cb",
@@ -3017,8 +2924,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00D3",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10d4",
@@ -3122,8 +3028,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00D8",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10d9",
@@ -3174,8 +3079,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00DC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10dd",
@@ -3195,16 +3099,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00DE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10df",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00DF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10e0",
@@ -3247,8 +3149,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00E2",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10e3",
@@ -3278,8 +3179,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00E4",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10e5",
@@ -3363,8 +3263,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00E9",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ea",
@@ -3384,16 +3283,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00EB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ec",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00EC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ed",
@@ -3423,8 +3320,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_00EE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ef",
@@ -3539,16 +3435,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00F5",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10f6",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00F6",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10f7",
@@ -3607,16 +3501,14 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00FB",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10fc",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00FC",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10fd",
@@ -3636,40 +3528,35 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00FE",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x10ff",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_00FF",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1100",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0100",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1101",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0101",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1102",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0102",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1103",
@@ -3737,8 +3624,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0105",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1106",
@@ -3758,8 +3644,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0107",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1108",
@@ -3815,8 +3700,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_010B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x110c",
@@ -3874,8 +3758,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_010E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x110f",
@@ -4049,8 +3932,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0118",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1119",
@@ -4103,8 +3985,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_011B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x111c",
@@ -4177,56 +4058,49 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_011E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x111f",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_011F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1120",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0120",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1121",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0121",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1122",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0122",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1123",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0123",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1124",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0124",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1125",
@@ -4272,64 +4146,56 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0128",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1129",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0129",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112a",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_012A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112b",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_012B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112c",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_012C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112d",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_012D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112e",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_012E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x112f",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_012F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1130",
@@ -4349,8 +4215,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0131",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1132",
@@ -4383,8 +4248,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0134",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1135",
@@ -4409,32 +4273,28 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0136",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1137",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0137",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1138",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0138",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1139",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0139",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x113a",
@@ -4454,16 +4314,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_013B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x113c",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_013C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x113d",
@@ -4483,24 +4341,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_013E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x113f",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_013F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1140",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0140",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1141",
@@ -4525,24 +4380,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0142",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1143",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0143",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1144",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0144",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1145",
@@ -4562,8 +4414,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0146",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1147",
@@ -4588,16 +4439,14 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0148",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1149",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0149",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x114a",
@@ -4650,8 +4499,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_014C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x114d",
@@ -4671,24 +4519,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_014E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x114f",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_014F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1150",
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_0150",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1151",
@@ -4708,24 +4553,21 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0152",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1153",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0153",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1154",
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0154",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1155",
@@ -4809,8 +4651,7 @@
     "ReturnType": "void",
     "Name": "DNG_FUNCTION_0159",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x115a",
@@ -4843,8 +4684,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_015C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x115d",
@@ -4877,8 +4717,7 @@
     "ReturnType": "int",
     "Name": "DNG_FUNCTION_015F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x1160",

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Event/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Event/Functions.json
@@ -40,24 +40,21 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4003",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0003",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4004",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4005",
@@ -100,8 +97,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0007",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4008",
@@ -134,8 +130,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x400b",
@@ -155,16 +150,14 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_000C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x400d",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x400e",
@@ -320,8 +313,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0016",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4017",
@@ -372,8 +364,7 @@
     "ReturnType": "int",
     "Name": "EVT_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x401b",
@@ -488,8 +479,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0021",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4022",
@@ -540,8 +530,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0025",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4026",
@@ -600,8 +589,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_002A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x402b",
@@ -636,8 +624,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_002C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x402d",
@@ -667,8 +654,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_002E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x402f",
@@ -755,8 +741,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4035",
@@ -776,8 +761,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0036",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4037",
@@ -797,8 +781,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0038",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4039",
@@ -818,8 +801,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x403b",
@@ -916,8 +898,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0040",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4041",
@@ -1075,8 +1056,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0048",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4049",
@@ -1096,8 +1076,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_004A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x404b",
@@ -1130,8 +1109,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_004D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x404e",
@@ -1151,16 +1129,14 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_004F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4050",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0050",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4051",
@@ -1180,8 +1156,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0052",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4053",
@@ -1201,8 +1176,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0054",
     "Description": "Code function name: cmpMisc_sub_455E18",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4055",
@@ -1235,64 +1209,56 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0057",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4058",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0058",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4059",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0059",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405a",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_005A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405b",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_005B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405c",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_005C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405d",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_005D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405e",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_005E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x405f",
@@ -1312,8 +1278,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0060",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4061",
@@ -1366,8 +1331,7 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0063",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x4064",
@@ -1444,24 +1408,21 @@
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_0069",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x406a",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_006A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x406b",
     "ReturnType": "void",
     "Name": "EVT_FUNCTION_006B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x406c",

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Facility/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Facility/Functions.json
@@ -4,24 +4,21 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6001",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0001",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6002",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6003",
@@ -41,32 +38,28 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6005",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6006",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0006",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6007",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0007",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6008",
@@ -99,16 +92,14 @@
     "ReturnType": "int",
     "Name": "FCL_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x600b",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_000B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x600c",
@@ -141,8 +132,7 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_000E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x600f",
@@ -175,16 +165,14 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0011",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6012",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0012",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6013",
@@ -204,16 +192,14 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0014",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6015",
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0015",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6016",
@@ -233,15 +219,13 @@
     "ReturnType": "void",
     "Name": "FCL_FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x6018",
     "ReturnType": "int",
     "Name": "FCL_FUNCTION_0018",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Map/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Map/Functions.json
@@ -4,24 +4,21 @@
     "ReturnType": "void",
     "Name": "MAP_FUNCTION_0000",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x7001",
     "ReturnType": "void",
     "Name": "MAP_FUNCTION_0001",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x7002",
     "ReturnType": "void",
     "Name": "MAP_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x7003",
@@ -41,15 +38,13 @@
     "ReturnType": "int",
     "Name": "MAP_FUNCTION_0004",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x7005",
     "ReturnType": "void",
     "Name": "MAP_FUNCTION_0005",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   }
 ]

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Script/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Script/Functions.json
@@ -53,8 +53,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_0003",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5004",
@@ -136,16 +135,14 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_0009",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x500a",
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_000A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x500b",
@@ -348,8 +345,7 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0017",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5018",
@@ -387,24 +383,21 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_001A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x501b",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_001B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x501c",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_001C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x501d",
@@ -424,8 +417,7 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_001E",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x501f",
@@ -450,8 +442,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_0020",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5021",
@@ -567,8 +558,7 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0024",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5025",
@@ -631,64 +621,56 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0027",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5028",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0028",
     "Description": "Code function name: fiction_sub_389A8C",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5029",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0029",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502a",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_002A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502b",
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_002B",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502c",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_002C",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502d",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_002D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502e",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_002E",
     "Description": "Code function name: shdPhoto_sub_38B414",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x502f",
@@ -713,8 +695,7 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0030",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5031",
@@ -757,24 +738,21 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0033",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5034",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0034",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5035",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0035",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5036",
@@ -794,8 +772,7 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0037",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5038",
@@ -828,8 +805,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_003A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x503b",
@@ -862,8 +838,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_003D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x503e",
@@ -1053,16 +1028,14 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_0049",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x504a",
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_004A",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x504b",
@@ -1136,8 +1109,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_004F",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5050",
@@ -1214,8 +1186,7 @@
     "ReturnType": "int",
     "Name": "SCR_FUNCTION_0055",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5056",
@@ -1448,24 +1419,21 @@
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0062",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5063",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0063",
     "Description": "Code function name: edBg_sub_46AB14",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5064",
     "ReturnType": "void",
     "Name": "SCR_FUNCTION_0064",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x5065",

--- a/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Window/Functions.json
+++ b/Source/AtlusScriptLibrary/Libraries/PersonaQ2/Modules/Window/Functions.json
@@ -17,16 +17,14 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0001",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2002",
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0002",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2003",
@@ -46,16 +44,14 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0004",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2005",
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0005",
     "Description": "Null pointer",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2006",
@@ -183,8 +179,7 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_000D",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x200e",
@@ -276,8 +271,7 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0013",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2014",
@@ -379,8 +373,7 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0019",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x201a",
@@ -559,8 +552,7 @@
     "ReturnType": "void",
     "Name": "WND_FUNCTION_0023",
     "Description": "",
-    "Parameters": [
-    ]
+    "Parameters": []
   },
   {
     "Index": "0x2024",


### PR DESCRIPTION
This adds "default" aliases to all of the flowscript function libraries where real names have been set at some point. 
For example, if a function would've originally been called `FUNCTION_0003` but is now `SEL`, I have added `FUNCTION_0003` as an alias. 

This is done automatically using the addAliases.py script which I've also updated to better handle things such as ignoring the games that had real names from the start like P5.

This is useful for allowing scripts that were decompiled using older libraries to continue to work.