### PR TITLE
Fix MessageScript encoding not being set when compiling flowscript

### DIFF
--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
@@ -71,7 +71,7 @@ public class FlowScriptCompiler
     public Encoding Encoding 
     {
         get => encoding; 
-        set => encoding = EncodingHelper.GetEncodingForEndianness(encoding, mFormatVersion.HasFlag(FormatVersion.BigEndian)); 
+        set => encoding = EncodingHelper.GetEncodingForEndianness(value, mFormatVersion.HasFlag(FormatVersion.BigEndian)); 
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes issue #100.

When compiling flowscript the encoding of any imported messagescripts was not being set as it was being set to itself (which was always null) instead of the new value. This caused the imported messagescripts to default back to ASCII encoding, breaking characters.