### PR TITLE
Expand all imports to full paths when resolving them

### DIFF
--- a/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
+++ b/Source/AtlusScriptLibrary/FlowScriptLanguage/Compiler/FlowScriptCompiler.cs
@@ -136,7 +136,7 @@ public class FlowScriptCompiler
     /// Tries to get a list of all files that would be imported (directly or transitively) when compiling a flowscript file.
     /// </summary>
     /// <param name="files">A List of paths to .bf, .flow, and .msg files to be used as a base when checking for imports.</param>
-    /// <param name="resolvedImports">A list of all imports found. This includes the passed in <paramref name="files"/>.</param>
+    /// <param name="resolvedImports">A list of full paths to all imports found. This includes the passed in <paramref name="files"/>.</param>
     /// <returns>True if imports could be resolved, false otherwise</returns>
     public bool TryGetImports(List<string> files, out string[] resolvedImports)
     {
@@ -918,6 +918,7 @@ public class FlowScriptCompiler
         }
 
         Info($"Importing MessageScript from file '{compilationUnitFilePath}'");
+        import.CompilationUnitFileName = compilationUnitFilePath;
 
         string messageScriptSource;
 
@@ -964,6 +965,7 @@ public class FlowScriptCompiler
         }
 
         Info($"Importing FlowScript from file '{compilationUnitFilePath}'");
+        import.CompilationUnitFileName = compilationUnitFilePath;
         FileStream flowScriptFileStream;
         try
         {
@@ -1017,6 +1019,7 @@ public class FlowScriptCompiler
         }
 
         Info($"Importing compiled FlowScript from file '{compilationUnitFilePath}'");
+        import.CompilationUnitFileName = compilationUnitFilePath;
         FileStream flowScriptFileStream;
         try
         {


### PR DESCRIPTION
When I added the TryCompile functions that return a list of sources as an out variable I stated that they were full paths to those imports. I've now realised that in some cases, like when the base flowscript directly imports a msg, not all imports actually end up getting expanded.

This pr just sets the `CompilationUnitFileName` to the resolved full path in each of the TryResolve functions to ensure that the sources are always full paths, if it successfully compiles.